### PR TITLE
Rename agent to SRE and expand telemetry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,413 +1,239 @@
-# Cloud Trace Analyzer Agent
+# SRE Agent
 
 [![Status](https://img.shields.io/badge/Status-Active-success)]()
 [![Python](https://img.shields.io/badge/Python-3.10%2B-blue)]()
 [![Framework](https://img.shields.io/badge/Framework-Google%20ADK-red)]()
 
-
-A Google ADK-based SRE assistant that performs sophisticated analysis on distributed traces using OpenTelemetry data. It combines BigQuery-powered aggregate analysis with detailed trace comparisons to identify performance regressions, errors, and behavioral changes.
+An ADK-based agent for analyzing telemetry data from Google Cloud Observability: **traces**, **logs**, and **metrics**. Specializes in distributed trace analysis with multi-stage investigation capabilities.
 
 ## Features
 
-- **Three-Stage Analysis Pipeline**:
-  - **Stage 0 (Aggregate)**: BigQuery-powered analysis of thousands of traces to identify patterns and trends
-  - **Stage 1 (Triage)**: Parallel comparison of specific traces to identify differences
-  - **Stage 2 (Deep Dive)**: Root cause analysis with log correlation
-- **BigQuery OpenTelemetry Integration**: Native support for OpenTelemetry schema in BigQuery, enabling:
-  - Aggregate metrics analysis (error rates, latency percentiles by service)
-  - Trend detection (when did performance degrade?)
-  - Time period comparison (before vs after)
-  - Exemplar trace selection (find representative baseline and outlier traces)
-  - Log correlation (find related logs for root cause analysis)
-- **Parallel Analysis Squads**: Uses **7 specialized agents**:
-  - **Aggregate Analyzer**: BigQuery-powered data analyst
-  - **Triage Squad**: Latency, Error, Structure, Statistics analyzers
-  - **Deep Dive Squad**: Causality and Service Impact analyzers
-- **Automatic Trace Discovery**: Intelligently identifies representative baseline (P50) and anomaly (P95 or error) traces
-- **Advanced Trace Filtering**: Supports complex filters including service names, HTTP status codes, min/max latency, and custom attribute matching
-- **Root Cause Synthesis**: Automatically identifies the critical path and performs causal analysis
-- **Cloud Console Integration**: Directly analyze traces by pasting their Google Cloud Console URL
+### Core Capabilities
 
-## Architecture
+1. **Trace Analysis** (Primary Specialization)
+   - Aggregate analysis using BigQuery (thousands of traces at scale)
+   - Individual trace inspection via Cloud Trace API
+   - Trace comparison (diff analysis) to identify what changed
+   - Pattern detection (N+1 queries, serial chains, bottlenecks)
+   - Root cause analysis through span-level investigation
 
-The agent is built using the Google Agent Development Kit (ADK). It uses a three-stage hierarchical orchestration pattern where a lead **SRE Detective** coordinates aggregate analysis, trace comparison, and deep-dive investigation.
+2. **Log Analysis**
+   - Query and analyze logs from Cloud Logging (MCP and direct API)
+   - Correlate logs with traces for root cause evidence
+   - Time-based analysis around incidents
 
-### Analysis Workflow
+3. **Metrics Analysis**
+   - Query time series data from Cloud Monitoring (MCP and direct API)
+   - PromQL queries for complex aggregations
+   - Trend detection and anomaly identification
+
+### Multi-Stage Trace Analysis Pipeline
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
-│  Stage 0: Aggregate Analysis (BigQuery)                        │
-│  • Analyze thousands of traces                                 │
-│  • Identify patterns, trends, problem services                 │
-│  • Select exemplar traces (baseline + outliers)                │
-│  • Detect when issues started                                  │
+│  Stage 0: Aggregate Analysis (BigQuery)                         │
+│  • Analyze thousands of traces                                  │
+│  • Identify patterns, trends, problem services                  │
+│  • Select exemplar traces (baseline + outliers)                 │
 └─────────────────────────────────────────────────────────────────┘
                             ↓
 ┌─────────────────────────────────────────────────────────────────┐
-│  Stage 1: Triage (Trace API)                                   │
-│  • Compare baseline vs anomaly traces                          │
-│  • Identify latency, error, structure differences             │
-│  • Statistical analysis of outliers                            │
+│  Stage 1: Triage (4 Parallel Analyzers)                         │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐ ┌─────────────┐│
+│  │  Latency    │ │   Error     │ │  Structure  │ │ Statistics  ││
+│  │  Analyzer   │ │  Analyzer   │ │  Analyzer   │ │  Analyzer   ││
+│  └─────────────┘ └─────────────┘ └─────────────┘ └─────────────┘│
 └─────────────────────────────────────────────────────────────────┘
                             ↓
 ┌─────────────────────────────────────────────────────────────────┐
-│  Stage 2: Deep Dive (Root Cause)                               │
-│  • Causal analysis on critical path                            │
-│  • Service impact assessment                                   │
-│  • Log correlation for root cause evidence                     │
+│  Stage 2: Deep Dive (2 Parallel Analyzers)                      │
+│  ┌───────────────────────────┐ ┌───────────────────────────────┐│
+│  │    Causality Analyzer     │ │  Service Impact Analyzer      ││
+│  │    (Root Cause)           │ │  (Blast Radius)               ││
+│  └───────────────────────────┘ └───────────────────────────────┘│
 └─────────────────────────────────────────────────────────────────┘
 ```
-
-### System Architecture
-
-```mermaid
-%%{init: {
-  'theme': 'base',
-  'themeVariables': {
-    'primaryColor': '#E8F0FE',
-    'primaryTextColor': '#1967D2',
-    'primaryBorderColor': '#1967D2',
-    'lineColor': '#5F6368',
-    'secondaryColor': '#F1F3F4',
-    'tertiaryColor': '#F3E5F5',
-    'fontFamily': 'inherit',
-    'fontSize': '14px'
-  }
-}}%%
-flowchart TB
-    %% --- TOP ROW: USER -> AGENT -> GEMINI ---
-    subgraph ControlRow [ ]
-        direction LR
-        User([👤 User])
-        Agent["🕵️ <b>Trace Analyzer Agent</b><br/>(Root Controller)"]
-        Gemini{{"🧠 <b>Gemini Model</b>"}}
-        
-        User <==> Agent
-        Agent <==> Gemini
-    end
-
-    %% --- MIDDLE ROW: SQUADS ---
-    subgraph Squads [ ]
-        direction LR
-        
-        subgraph Triage [🚦 Triage Squad]
-            direction TB
-            L["⏱️ Latency<br/>Sub-Agent"]
-            E["💥 Error<br/>Sub-Agent"]
-            S["🏗️ Structure<br/>Sub-Agent"]
-            ST["📊 Stats<br/>Sub-Agent"]
-            
-            %% Using invisible links to maintain vertical alignment without lines
-            L ~~~ E
-            S ~~~ ST
-        end
-        
-        subgraph DeepDive [🔍 Deep Dive Squad]
-            direction TB
-            C["🔗 Causality<br/>Sub-Agent"]
-            SI["🌊 Impact<br/>Sub-Agent"]
-            
-            C ~~~ SI
-        end
-    end
-
-    %% --- BOTTOM ROW: TOOLS ---
-    subgraph ToolLayer [Integrated Tools]
-        direction LR
-        TraceAPI["☁️ Trace API"]
-        BQ["🗄️ BigQuery MCP"]
-        TQB["🛠️ Query Builder"]
-    end
-
-    %% --- CONNECTIONS ---
-    Agent ==> Triage
-    Agent ==> DeepDive
-
-    %% Usage Flow (Dotted)
-    Agent -.-> ToolLayer
-    Triage -.-> ToolLayer
-    DeepDive -.-> ToolLayer
-
-    %% --- STYLING ---
-    style ControlRow fill:none,stroke:none
-    style Squads fill:none,stroke:none
-    
-    classDef userNode fill:#FFFFFF,stroke:#3C4043,stroke-width:2px,color:#3C4043;
-    classDef agentNode fill:#1A73E8,stroke:#174EA6,stroke-width:2px,color:#FFFFFF;
-    classDef brainNode fill:#F3E8FF,stroke:#9333EA,stroke-width:2px,stroke-dasharray: 5 5,color:#7E22CE;
-    classDef squadNode fill:#E8F0FE,stroke:#1967D2,stroke-width:1px,color:#1967D2;
-    classDef toolNode fill:#F1F3F4,stroke:#5F6368,stroke-width:1px,color:#3C4043;
-
-    class User userNode;
-    class Agent agentNode;
-    class Gemini brainNode;
-    class L,E,S,ST,C,SI squadNode;
-    class TraceAPI,BQ,TQB toolNode;
-```
-
-### Interaction Workflow
-
-```mermaid
-%%{init: {
-  'theme': 'base',
-  'themeVariables': {
-    'primaryColor': '#E8F0FE',
-    'primaryTextColor': '#1967D2',
-    'primaryBorderColor': '#1967D2',
-    'lineColor': '#5F6368',
-    'fontFamily': 'inherit',
-    'fontSize': '14px',
-    'noteBkgColor': '#FEF7E0',
-    'noteBorderColor': '#F9AB00',
-    'noteTextColor': '#3C4043',
-    'activationBkgColor': '#E8F0FE',
-    'activationBorderColor': '#1967D2'
-  }
-}}%%
-sequenceDiagram
-    actor User
-    participant Det as 🕵️ Detective
-    participant Tools as 🛠️ Tools
-    participant S1 as 🚨 Triage
-    participant S2 as 🤿 Deep Dive
-
-    Note over User, S2: 🔎 PHASE 1: EVIDENCE GATHERING
-
-    User->>Det: 1. "Analyze these traces..."
-    Det->>Tools: 2. Fetch Trace Data
-    activate Tools
-    Tools-->>Det: 3. Trace Data
-    deactivate Tools
-
-    Note over User, S2: ⚡ PHASE 2: IDENTIFICATION
-
-    Det->>S1: 4. Run Analysis
-    activate S1
-    S1->>S1: 5. Check Latency/Errors
-    S1-->>Det: 6. Suspects Found
-    deactivate S1
-    
-    Det->>User: 7. "I found latency spikes..."
-
-    Note over User, S2: 🕵️ PHASE 3: ROOT CAUSE
-
-    User->>Det: 8. "Dig deeper"
-    
-    Det->>S2: 9. Deep Dive
-    activate S2
-    S2->>S2: 10. Causal Analysis
-    S2-->>Det: 11. Root Cause
-    deactivate S2
-
-    Note over User, S2: 📝 PHASE 4: VERDICT
-    
-    Det->>User: 12. 📂 FINAL CASE FILE
-```
-
-### Core Components
-- **SRE Detective (Root)**: The orchestrator with an "SRE Detective" persona that synthesizes findings into a "Case File". It uses a three-stage workflow optimized for production investigations.
-- **Aggregate Analyzer (Stage 0)**: Uses BigQuery to analyze OpenTelemetry trace data at scale, identifying patterns, trends, and selecting exemplar traces.
-- **Triage Squad (Stage 1)**: Rapidly identifies *what* is wrong (Latency, Errors, Structure, Stats) by comparing specific traces.
-- **Deep Dive Squad (Stage 2)**: Investigates *why* it happened (Causality) and *who* else is affected (Service Impact), with log correlation.
-- **Dynamic MCP Integration**: Uses `ApiRegistry` to lazily load BigQuery tools, ensuring cross-platform stability.
-
-### OpenTelemetry BigQuery Schema Support
-
-The agent expects traces to be exported to BigQuery using the OpenTelemetry schema:
-
-**Required Table Structure** (example: `project.telemetry._AllSpans`):
-- `trace_id`: Unique trace identifier
-- `span_id`: Unique span identifier
-- `parent_span_id`: Parent span reference
-- `span_name`: Operation name
-- `start_time`: Span start timestamp
-- `end_time`: Span end timestamp
-- `duration`: Span duration in nanoseconds
-- `status_code`: OK, ERROR, UNSET
-- `service_name`: Service identifier (from resource attributes)
-- `attributes`: Key-value pairs (STRUCT or JSON)
-
-**Optional Table for Logs** (example: `project.telemetry.otel_logs`):
-- `trace_id`: Correlation with traces
-- `timestamp`: Log timestamp
-- `severity_text`: ERROR, WARN, INFO, etc.
-- `body`: Log message
-- `resource_attributes`: Service metadata
-
-## Setup
-
-### 1. Install Dependencies
-
-The project uses `uv` for high-performance dependency management:
-
-```bash
-cd trace_analyzer
-uv sync
-```
-
-### 2. Configure Environment
-
-Copy the example environment file and configure your Google Cloud project:
-
-```bash
-cp .env.example .env
-```
-
-Key variables in `.env`:
-```bash
-# Required for Cloud Trace and BigQuery access
-GOOGLE_CLOUD_PROJECT=your-gcp-project
-GOOGLE_CLOUD_LOCATION=us-central1
-
-# Agent Engine Configuration
-GOOGLE_GENAI_USE_VERTEXAI=1
-```
-
-### 3. Ensure IAM Permissions
-
-The authenticated user or service account requires:
-- `roles/cloudtrace.user`
-- `roles/bigquery.dataViewer`
-- `roles/bigquery.jobUser`
-
-## Deployment
-
-### Deployment (Standard ADK CLI)
- 
- If you prefer using the standard `adk` CLI, you can pass environment variables via an env file:
- 
- ```bash
- # 1. Ensure env vars are in trace_analyzer/telemetry.env
- # 2. Deploy using the --env_file flag
- uv run adk deploy agent_engine \
-   --project=your-project \
-   --region=us-central1 \
-   --staging_bucket=your-bucket \
-   --display_name="Trace Analyzer" \
-   --env_file trace_analyzer/telemetry.env \
-   trace_analyzer
- ```
- 
- ### Deployment (Custom Script)
- 
- We also provide a custom deployment script that supports direct flags:
- 
- ```bash
- # Basic deployment
- uv run python deploy/deploy.py --create
- ```
-
-The script will create a Reasoning Engine (Agent Engine) resource and output its resource name.
-
-## Usage
-
-### Running the Agent
-
-```bash
-# Launch the interactive terminal UI
-uv run adk run .
-
-# Launch the web-based interface
-uv run adk web
-```
-
-### Example Prompts
-
-**SRE Investigation with BigQuery (Recommended):**
-> "Analyze traces in my BigQuery dataset `myproject.telemetry` for the last 24 hours. Which services are having issues?"
-
-> "Start broad: analyze aggregate metrics for the checkout-service, find when performance degraded, then deep-dive into exemplar traces."
-
-> "Compare traces from yesterday (baseline) vs today (anomaly) for the payment-service."
-
-**Quick Trace Comparison:**
-> "Find example traces in my project from the last 4 hours and show me what's different between a typical request and a slow one."
-
-**Specific Investigation:**
-> "Analyze this trace from the production console: https://console.cloud.google.com/traces/details/[TRACE_ID]?project=[PROJECT_ID]"
-
-**Service-Specific Filtering:**
-> "Find traces for the 'payment-processor' service with latency > 500ms and compare them to the baseline."
-
-**Root Cause with Log Correlation:**
-> "Deep-dive into trace xyz789 and find correlated logs to identify the root cause."
-
-**Trend Detection:**
-> "Detect when the P95 latency started increasing for the user-service in the last 72 hours."
 
 ## Project Structure
 
 ```
-trace_analyzer/
-├── trace_analyzer/
-│   ├── agent.py          # Root orchestrator ("SRE Detective")
-│   ├── sub_agents/       # Specialized analysis agents
-│   │   ├── aggregate/    # Aggregate Analyzer (BigQuery)
-│   │   ├── latency/      # Latency Analyzer
-│   │   ├── error/        # Error Analyzer
-│   │   ├── structure/    # Structure Analyzer
-│   │   ├── statistics/   # Statistics Analyzer
-│   │   ├── causality/    # Causality Analyzer
-│   │   └── service_impact/ # Service Impact Analyzer
-│   ├── tools/
-│   │   ├── bigquery_otel.py    # BigQuery OpenTelemetry analysis tools
-│   │   ├── o11y_clients.py     # Shared Observability (Trace/Log/Error) Client
-│   │   ├── trace_filter.py     # Advanced TraceQueryBuilder
-│   │   ├── statistical_analysis.py  # Statistical analysis tools
-│   │   └── ...
-│   └── prompt.py         # Advanced multi-turn prompting logic
-├── tests/                # Comprehensive test suite
-├── deployment/           # Deployment scripts
-├── AGENTS.md             # Developer & Contributor guide
-├── pyproject.toml        # uv-based build configuration
-└── README.md
+sre_agent/
+├── agent.py              # Main SRE Agent definition
+├── prompt.py             # Agent prompts and instructions
+├── schema.py             # Pydantic schemas for structured outputs
+├── tools/
+│   ├── common/           # Shared utilities
+│   │   ├── decorators.py # @adk_tool with OTel instrumentation
+│   │   ├── telemetry.py  # Telemetry helpers
+│   │   └── cache.py      # Thread-safe caching
+│   ├── gcp/              # GCP service tools
+│   │   ├── mcp.py        # MCP toolset integration
+│   │   └── clients.py    # Direct API clients
+│   ├── trace/            # Trace analysis tools
+│   │   ├── clients.py    # Cloud Trace API
+│   │   ├── analysis.py   # Span analysis utilities
+│   │   ├── comparison.py # Trace comparison
+│   │   └── filters.py    # Query builders
+│   └── bigquery/         # BigQuery analysis tools
+│       └── otel.py       # OpenTelemetry schema queries
+└── sub_agents/
+    └── trace_analysis/   # Specialized trace sub-agents
+        └── agents.py     # 7 sub-agents for multi-stage analysis
 ```
 
-## Reliability & Performance
+## Quick Start
 
-- **Lazy MCP Loading**: Implements `LazyMcpRegistryToolset` to prevent session conflicts in ASGI/uvicorn environments, ensuring stable deployment.
-- **Observability**: Fully instrumented with OpenTelemetry for tracking tool execution and agent performance.
-- **Truncation & Noise Reduction**: Advanced logging patterns ensure that large trace datasets don't overwhelm LLM context windows.
-- **Scalable Analysis**: BigQuery integration allows analyzing millions of traces without overwhelming the Trace API.
-- **Parallel Processing**: Triage and Deep Dive squads run analyzers in parallel for faster insights.
+### Prerequisites
 
-## BigQuery Setup (Optional but Recommended)
+- Python 3.10+
+- Google Cloud SDK configured
+- Access to a GCP project with Cloud Trace data
 
-To enable the full SRE investigation workflow with aggregate analysis:
+### Installation
 
-1. **Export traces to BigQuery**: Set up OpenTelemetry trace export to BigQuery
-   - Use the [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) with BigQuery exporter
-   - Or use [Cloud Trace BigQuery export](https://cloud.google.com/trace/docs/trace-export)
+```bash
+# Install dependencies using uv
+uv sync
 
-2. **Configure BigQuery dataset**: Ensure your BigQuery dataset contains a table with the OpenTelemetry schema
-   ```bash
-   # Example dataset: myproject.telemetry
-   # Example table: _AllSpans
-   ```
+# Copy and configure environment
+cp .env.example .env
+# Edit .env with your GCP project settings
+```
 
-3. **Grant BigQuery permissions**: Ensure the agent has access
-   ```bash
-   gcloud projects add-iam-policy-binding PROJECT_ID \
-     --member="serviceAccount:SERVICE_ACCOUNT" \
-     --role="roles/bigquery.dataViewer"
-   ```
+### Environment Configuration
 
-4. **Use aggregate analysis in prompts**:
-   ```
-   "Analyze traces in dataset myproject.telemetry for the last 24 hours"
-   ```
+```bash
+# Required: GCP project with telemetry data
+GOOGLE_CLOUD_PROJECT=your-gcp-project
 
-**Note**: The agent works without BigQuery (using Cloud Trace API only), but BigQuery enables more sophisticated SRE workflows with aggregate analysis, trend detection, and exemplar selection at scale.
+# Optional: Override trace project if different
+TRACE_PROJECT_ID=your-trace-project
 
-## Troubleshooting
+# Optional: Vertex AI settings
+GOOGLE_GENAI_USE_VERTEXAI=1
+GOOGLE_CLOUD_LOCATION=us-central1
+```
 
-- **`ValueError: stale session`**: This usually happens if the local database state gets out of sync with the running agent. Try clearing the `.adk` directory or restarting the server.
-- **Permission Errors**: Ensure you have run `gcloud auth application-default login` and that your user has `roles/cloudtrace.user` and `roles/bigquery.dataViewer`.
-- **ASGI Errors**: If you see "ASGI callable returned without completing response", ensure you are using the latest version of the ADK and that `LazyMcpRegistryToolset` is being used for MCP tools.
+### Running the Agent
 
-## Contributing
+```bash
+# Interactive terminal (new SRE Agent)
+uv run adk run sre_agent
 
-See [AGENTS.md](./AGENTS.md) for detailed developer workflows, testing instructions, and PR guidelines.
+# Web interface
+uv run adk web sre_agent
+
+# Legacy trace_analyzer (still available)
+uv run adk run trace_analyzer
+```
+
+## Usage Examples
+
+### Trace Analysis
+
+```
+# Analyze recent traces
+"What's the health of the checkout-service in the last 24 hours?"
+
+# Find performance issues
+"Find slow traces and identify the root cause"
+
+# Compare traces
+"Compare trace abc123 with trace def456"
+
+# BigQuery aggregate analysis
+"Analyze traces in BigQuery dataset my_project.telemetry"
+```
+
+### Log Analysis
+
+```
+# Search for errors
+"Find ERROR level logs in the last hour"
+
+# Correlate with traces
+"Get logs for trace abc123"
+```
+
+### Metrics Analysis
+
+```
+# Query metrics
+"Show CPU utilization for the frontend service"
+
+# PromQL queries
+"What's the rate of HTTP 5xx errors?"
+```
+
+## Available Tools
+
+### BigQuery Tools
+| Tool | Description |
+|------|-------------|
+| `analyze_aggregate_metrics` | Aggregate trace metrics |
+| `find_exemplar_traces` | Find representative traces |
+| `compare_time_periods` | Compare metrics between windows |
+| `detect_trend_changes` | Find when metrics degraded |
+| `correlate_logs_with_trace` | Find logs for a trace |
+
+### Cloud Trace Tools
+| Tool | Description |
+|------|-------------|
+| `fetch_trace` | Get full trace by ID |
+| `list_traces` | List traces with filtering |
+| `find_example_traces` | Smart trace discovery |
+| `compare_span_timings` | Compare two traces |
+| `find_structural_differences` | Compare structures |
+
+### Cloud Logging Tools
+| Tool | Description |
+|------|-------------|
+| `mcp_list_log_entries` | Query logs via MCP |
+| `list_log_entries` | Query logs via API |
+| `get_logs_for_trace` | Get logs for a trace |
+
+### Cloud Monitoring Tools
+| Tool | Description |
+|------|-------------|
+| `mcp_list_timeseries` | Query metrics via MCP |
+| `mcp_query_range` | PromQL queries via MCP |
+| `list_time_series` | Query metrics via API |
+
+## Sub-Agents
+
+| Sub-Agent | Stage | Role |
+|-----------|-------|------|
+| `aggregate_analyzer` | 0 | BigQuery analysis |
+| `latency_analyzer` | 1 | Timing comparison |
+| `error_analyzer` | 1 | Error detection |
+| `structure_analyzer` | 1 | Topology analysis |
+| `statistics_analyzer` | 1 | Outlier detection |
+| `causality_analyzer` | 2 | Root cause |
+| `service_impact_analyzer` | 2 | Blast radius |
+
+## Development
+
+### Running Tests
+
+```bash
+uv run pytest
+uv run pytest -v
+```
+
+### Code Quality
+
+```bash
+uv run flake8 sre_agent/
+```
+
+## IAM Permissions
+
+Required roles for the service account:
+
+- `roles/cloudtrace.user` - Read traces
+- `roles/logging.viewer` - Read logs
+- `roles/monitoring.viewer` - Read metrics
+- `roles/bigquery.dataViewer` - Query BigQuery (if using BigQuery tools)
 
 ## License
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
-name = "trace-analyzer"
-version = "0.1.0"
-description = "A Google ADK-based Cloud Trace Analyzer Agent for distributed trace diff analysis"
+name = "sre-agent"
+version = "0.2.0"
+description = "SRE Agent - Google Cloud Observability analysis agent for traces, logs, and metrics"
 authors = [{ name = "SRT", email = "srtuxx@gmail.com" }]
 license = "Apache-2.0"
 readme = "README.md"
@@ -52,7 +52,7 @@ select = ["E", "F", "W", "I", "B", "UP", "RUF"]
 ignore = ["E501", "C901"]
 
 [tool.ruff.lint.isort]
-known-first-party = ["trace_analyzer"]
+known-first-party = ["sre_agent", "trace_analyzer"]
 
 [tool.pytest.ini_options]
 pythonpath = "."
@@ -73,7 +73,7 @@ url = "https://pypi.org/simple"
 default = true
 
 [tool.agent-starter-pack]
-example_question = "Compare trace abc123 with trace def456 in project my-gcp-project"
+example_question = "Analyze traces and logs in project my-gcp-project to find performance issues"
 
 [tool.agent-starter-pack.settings]
-agent_directory = "trace_analyzer"
+agent_directory = "sre_agent"

--- a/sre_agent/__init__.py
+++ b/sre_agent/__init__.py
@@ -1,0 +1,18 @@
+"""SRE Agent - Google Cloud Observability Analysis Agent.
+
+An ADK-based agent for analyzing telemetry data from Google Cloud Observability:
+traces, logs, and metrics. Specializes in distributed trace analysis with
+multi-stage investigation.
+
+Usage:
+    from sre_agent import root_agent
+
+    # Or with MCP tools
+    from sre_agent.agent import get_agent_with_mcp_tools
+    agent = await get_agent_with_mcp_tools()
+"""
+
+from .agent import root_agent, sre_agent
+from . import tools
+
+__all__ = ["root_agent", "sre_agent", "tools"]

--- a/sre_agent/agent.py
+++ b/sre_agent/agent.py
@@ -1,0 +1,417 @@
+"""SRE Agent - Google Cloud Observability Analysis Agent.
+
+This is the main agent for SRE tasks, specializing in analyzing telemetry data
+from Google Cloud Observability: traces, logs, and metrics.
+
+The agent uses a hierarchical architecture for trace analysis:
+- Stage 0 (Aggregate): BigQuery-powered analysis of thousands of traces
+- Stage 1 (Triage): Parallel analysis with 4 specialized sub-agents
+- Stage 2 (Deep Dive): Root cause and impact analysis
+
+For other tasks (logs, metrics), the agent uses direct tools.
+"""
+
+import asyncio
+import logging
+import os
+from typing import Any
+
+import google.auth
+from google.adk.agents import LlmAgent
+from google.adk.tools import ToolContext
+
+from .prompt import SRE_AGENT_PROMPT
+from .tools import (
+    # Trace tools
+    fetch_trace,
+    list_traces,
+    find_example_traces,
+    get_trace_by_url,
+    calculate_span_durations,
+    extract_errors,
+    build_call_graph,
+    summarize_trace,
+    validate_trace_quality,
+    compare_span_timings,
+    find_structural_differences,
+    # GCP direct API tools
+    list_log_entries,
+    list_time_series,
+    list_error_events,
+    get_logs_for_trace,
+    get_current_time,
+    # BigQuery tools
+    analyze_aggregate_metrics,
+    find_exemplar_traces,
+    compare_time_periods,
+    detect_trend_changes,
+    correlate_logs_with_trace,
+)
+from .tools.gcp.mcp import (
+    create_bigquery_mcp_toolset,
+    create_logging_mcp_toolset,
+    create_monitoring_mcp_toolset,
+    mcp_list_log_entries,
+    mcp_list_timeseries,
+    mcp_query_range,
+    get_project_id_with_fallback,
+)
+
+# Import sub-agents for trace analysis
+from .sub_agents import (
+    aggregate_analyzer,
+    latency_analyzer,
+    error_analyzer,
+    structure_analyzer,
+    statistics_analyzer,
+    causality_analyzer,
+    service_impact_analyzer,
+)
+
+logger = logging.getLogger(__name__)
+
+# ============================================================================
+# MCP Toolset Management
+# ============================================================================
+
+# Lazy-loaded MCP toolsets (created on first use in async context)
+_bigquery_mcp_toolset = None
+_logging_mcp_toolset = None
+_monitoring_mcp_toolset = None
+
+
+async def _get_bigquery_mcp_toolset():
+    """Lazily create BigQuery MCP toolset in async context."""
+    global _bigquery_mcp_toolset
+    if _bigquery_mcp_toolset is None:
+        _bigquery_mcp_toolset = create_bigquery_mcp_toolset()
+    return _bigquery_mcp_toolset
+
+
+async def _get_logging_mcp_toolset():
+    """Lazily create Cloud Logging MCP toolset in async context."""
+    global _logging_mcp_toolset
+    if _logging_mcp_toolset is None:
+        _logging_mcp_toolset = create_logging_mcp_toolset()
+    return _logging_mcp_toolset
+
+
+async def _get_monitoring_mcp_toolset():
+    """Lazily create Cloud Monitoring MCP toolset in async context."""
+    global _monitoring_mcp_toolset
+    if _monitoring_mcp_toolset is None:
+        _monitoring_mcp_toolset = create_monitoring_mcp_toolset()
+    return _monitoring_mcp_toolset
+
+
+# ============================================================================
+# Base Tools (always available)
+# ============================================================================
+
+base_tools = [
+    # Trace API tools
+    fetch_trace,
+    list_traces,
+    find_example_traces,
+    get_trace_by_url,
+    # Trace analysis tools
+    calculate_span_durations,
+    extract_errors,
+    build_call_graph,
+    summarize_trace,
+    validate_trace_quality,
+    # Trace comparison tools
+    compare_span_timings,
+    find_structural_differences,
+    # GCP direct API tools
+    list_log_entries,
+    list_time_series,
+    list_error_events,
+    get_logs_for_trace,
+    get_current_time,
+    # BigQuery OTel tools
+    analyze_aggregate_metrics,
+    find_exemplar_traces,
+    compare_time_periods,
+    detect_trend_changes,
+    correlate_logs_with_trace,
+    # MCP tools (wrapper functions)
+    mcp_list_log_entries,
+    mcp_list_timeseries,
+    mcp_query_range,
+]
+
+
+# ============================================================================
+# Orchestration Functions
+# ============================================================================
+
+
+async def run_aggregate_analysis(
+    dataset_id: str,
+    table_name: str,
+    time_window_hours: int = 24,
+    service_name: str | None = None,
+    tool_context: ToolContext = None,
+) -> dict[str, Any]:
+    """
+    Run Stage 0: Aggregate analysis using BigQuery.
+
+    This stage analyzes thousands of traces to identify patterns, trends,
+    and select exemplar traces for detailed investigation.
+
+    Args:
+        dataset_id: BigQuery dataset ID (e.g., 'project.dataset')
+        table_name: Table name containing OTel traces
+        time_window_hours: Time window for analysis
+        service_name: Optional service filter
+        tool_context: ADK tool context
+
+    Returns:
+        Aggregate analysis results with recommended traces.
+    """
+    logger.info(f"Running aggregate analysis on {dataset_id}.{table_name}")
+
+    try:
+        # Run aggregate analyzer sub-agent
+        result = await aggregate_analyzer.run_async(
+            user_content=f"""
+Analyze trace data in BigQuery:
+- Dataset: {dataset_id}
+- Table: {table_name}
+- Time window: {time_window_hours} hours
+{f"- Service filter: {service_name}" if service_name else ""}
+
+Please:
+1. Get aggregate metrics for all services
+2. Identify services with high error rates or latency
+3. Find exemplar traces for comparison (baseline and outlier)
+4. Report your findings
+""",
+            tool_context=tool_context,
+        )
+
+        return {
+            "stage": "aggregate",
+            "status": "success",
+            "result": result,
+        }
+
+    except Exception as e:
+        logger.error(f"Aggregate analysis failed: {e}", exc_info=True)
+        return {
+            "stage": "aggregate",
+            "status": "error",
+            "error": str(e),
+        }
+
+
+async def run_triage_analysis(
+    baseline_trace_id: str,
+    target_trace_id: str,
+    project_id: str | None = None,
+    tool_context: ToolContext = None,
+) -> dict[str, Any]:
+    """
+    Run Stage 1: Parallel triage analysis with 4 specialized sub-agents.
+
+    This stage compares two traces in parallel using:
+    - Latency Analyzer: Timing comparison
+    - Error Analyzer: Error detection
+    - Structure Analyzer: Call graph comparison
+    - Statistics Analyzer: Statistical anomaly detection
+
+    Args:
+        baseline_trace_id: ID of the reference (good) trace
+        target_trace_id: ID of the trace to investigate
+        project_id: GCP project ID (optional, uses env if not provided)
+        tool_context: ADK tool context
+
+    Returns:
+        Combined results from all triage analyzers.
+    """
+    if not project_id:
+        project_id = get_project_id_with_fallback()
+
+    logger.info(f"Running triage analysis: {baseline_trace_id} vs {target_trace_id}")
+
+    prompt = f"""
+Analyze the differences between these two traces:
+- Baseline (good): {baseline_trace_id}
+- Target (investigate): {target_trace_id}
+- Project: {project_id}
+
+Compare them and report your findings.
+"""
+
+    # Run all triage analyzers in parallel
+    results = await asyncio.gather(
+        latency_analyzer.run_async(user_content=prompt, tool_context=tool_context),
+        error_analyzer.run_async(user_content=prompt, tool_context=tool_context),
+        structure_analyzer.run_async(user_content=prompt, tool_context=tool_context),
+        statistics_analyzer.run_async(user_content=prompt, tool_context=tool_context),
+        return_exceptions=True,
+    )
+
+    agent_names = ["latency", "error", "structure", "statistics"]
+    triage_results = {}
+
+    for name, result in zip(agent_names, results):
+        if isinstance(result, Exception):
+            logger.error(f"{name}_analyzer failed: {result}")
+            triage_results[name] = {"status": "error", "error": str(result)}
+        else:
+            triage_results[name] = {"status": "success", "result": result}
+
+    return {
+        "stage": "triage",
+        "baseline_trace_id": baseline_trace_id,
+        "target_trace_id": target_trace_id,
+        "results": triage_results,
+    }
+
+
+async def run_deep_dive_analysis(
+    baseline_trace_id: str,
+    target_trace_id: str,
+    triage_findings: dict[str, Any],
+    project_id: str | None = None,
+    tool_context: ToolContext = None,
+) -> dict[str, Any]:
+    """
+    Run Stage 2: Deep dive analysis with causality and impact sub-agents.
+
+    This stage determines:
+    - Causality: What is the root cause of the issue?
+    - Service Impact: What is the blast radius?
+
+    Args:
+        baseline_trace_id: ID of the baseline trace
+        target_trace_id: ID of the target trace
+        triage_findings: Results from Stage 1 triage
+        project_id: GCP project ID
+        tool_context: ADK tool context
+
+    Returns:
+        Root cause analysis and service impact assessment.
+    """
+    if not project_id:
+        project_id = get_project_id_with_fallback()
+
+    logger.info(f"Running deep dive analysis for trace {target_trace_id}")
+
+    prompt = f"""
+Based on the triage findings, perform deep analysis:
+
+Traces:
+- Baseline: {baseline_trace_id}
+- Target: {target_trace_id}
+- Project: {project_id}
+
+Triage Summary:
+{triage_findings}
+
+Determine root cause and assess impact.
+"""
+
+    # Run deep dive analyzers in parallel
+    results = await asyncio.gather(
+        causality_analyzer.run_async(user_content=prompt, tool_context=tool_context),
+        service_impact_analyzer.run_async(user_content=prompt, tool_context=tool_context),
+        return_exceptions=True,
+    )
+
+    agent_names = ["causality", "service_impact"]
+    deep_dive_results = {}
+
+    for name, result in zip(agent_names, results):
+        if isinstance(result, Exception):
+            logger.error(f"{name}_analyzer failed: {result}")
+            deep_dive_results[name] = {"status": "error", "error": str(result)}
+        else:
+            deep_dive_results[name] = {"status": "success", "result": result}
+
+    return {
+        "stage": "deep_dive",
+        "results": deep_dive_results,
+    }
+
+
+# ============================================================================
+# Main Agent Definition
+# ============================================================================
+
+# Create the main SRE Agent
+sre_agent = LlmAgent(
+    name="sre_agent",
+    model="gemini-2.5-pro",
+    description=(
+        "SRE Agent for Google Cloud Observability. Analyzes traces, logs, and metrics "
+        "to diagnose production issues. Specializes in distributed trace analysis with "
+        "multi-stage investigation: aggregate analysis, triage, and deep dive."
+    ),
+    instruction=SRE_AGENT_PROMPT,
+    tools=base_tools,
+    # Sub-agents for specialized analysis (automatically invoked based on task)
+    sub_agents=[
+        aggregate_analyzer,
+        latency_analyzer,
+        error_analyzer,
+        structure_analyzer,
+        statistics_analyzer,
+        causality_analyzer,
+        service_impact_analyzer,
+    ],
+)
+
+# Export as root_agent for ADK CLI compatibility
+root_agent = sre_agent
+
+# ============================================================================
+# Dynamic Tool Loading
+# ============================================================================
+
+
+async def get_agent_with_mcp_tools():
+    """
+    Creates an agent instance with MCP toolsets loaded.
+
+    This should be called in an async context to properly initialize
+    MCP toolsets. Use this for programmatic agent creation.
+
+    Returns:
+        LlmAgent with MCP tools added.
+    """
+    # Get MCP toolsets
+    bq_toolset = await _get_bigquery_mcp_toolset()
+    logging_toolset = await _get_logging_mcp_toolset()
+    monitoring_toolset = await _get_monitoring_mcp_toolset()
+
+    # Combine all tools
+    all_tools = list(base_tools)
+
+    # Add MCP toolsets if available
+    if bq_toolset:
+        all_tools.append(bq_toolset)
+    if logging_toolset:
+        all_tools.append(logging_toolset)
+    if monitoring_toolset:
+        all_tools.append(monitoring_toolset)
+
+    # Create agent with all tools
+    return LlmAgent(
+        name="sre_agent",
+        model="gemini-2.5-pro",
+        description=sre_agent.description,
+        instruction=SRE_AGENT_PROMPT,
+        tools=all_tools,
+        sub_agents=[
+            aggregate_analyzer,
+            latency_analyzer,
+            error_analyzer,
+            structure_analyzer,
+            statistics_analyzer,
+            causality_analyzer,
+            service_impact_analyzer,
+        ],
+    )

--- a/sre_agent/prompt.py
+++ b/sre_agent/prompt.py
@@ -1,0 +1,115 @@
+"""Prompt definitions for the SRE Agent."""
+
+SRE_AGENT_PROMPT = """
+You are the **SRE Agent** - an expert Site Reliability Engineer assistant specializing
+in Google Cloud Observability. You help diagnose production issues by analyzing
+telemetry data: traces, logs, and metrics.
+
+## Core Capabilities
+
+### 1. Trace Analysis (Primary Specialization)
+You excel at distributed trace analysis for debugging performance issues:
+- Aggregate trace analysis using BigQuery (thousands of traces at scale)
+- Individual trace inspection via Cloud Trace API
+- Trace comparison to identify what changed (diff analysis)
+- Pattern detection (N+1 queries, serial chains, bottlenecks)
+- Root cause analysis through span-level investigation
+
+### 2. Log Analysis
+Query and analyze logs from Cloud Logging:
+- Search for errors, warnings, and specific patterns
+- Correlate logs with traces for root cause evidence
+- Time-based analysis around incidents
+- Service-specific log investigation
+
+### 3. Metrics Analysis
+Query time series data from Cloud Monitoring:
+- CPU, memory, and resource utilization
+- Request rates, error rates, latency percentiles
+- PromQL queries for complex aggregations
+- Trend detection and anomaly identification
+
+## Available Tools
+
+### BigQuery Tools (for large-scale analysis)
+- `analyze_aggregate_metrics`: Analyze traces at scale (error rates, latency percentiles)
+- `find_exemplar_traces`: Find representative traces (baseline, outliers, errors)
+- `compare_time_periods`: Compare metrics between time periods
+- `detect_trend_changes`: Find when performance degraded
+- `correlate_logs_with_trace`: Find logs for a trace
+- BigQuery MCP tools: `execute_sql`, `list_dataset_ids`, `list_table_ids`
+
+### Cloud Trace Tools
+- `fetch_trace`: Get full trace details by ID
+- `list_traces`: List traces with filtering
+- `find_example_traces`: Smart trace discovery
+- `get_trace_by_url`: Parse Cloud Console URLs
+- `calculate_span_durations`: Extract span timing
+- `extract_errors`: Find error spans
+- `build_call_graph`: Build trace hierarchy
+- `compare_span_timings`: Compare two traces
+- `find_structural_differences`: Compare trace structures
+
+### Cloud Logging Tools
+- `mcp_list_log_entries`: Query logs via MCP
+- `list_log_entries`: Query logs via direct API
+- `get_logs_for_trace`: Get logs for a specific trace
+
+### Cloud Monitoring Tools
+- `mcp_list_timeseries`: Query metrics via MCP
+- `mcp_query_range`: PromQL queries via MCP
+- `list_time_series`: Query metrics via direct API
+
+## Recommended Workflow
+
+### For Performance Investigation:
+1. **Start Broad**: Use `analyze_aggregate_metrics` to understand overall health
+2. **Identify Problems**: Find services with high error rates or latency
+3. **Find Exemplars**: Use `find_exemplar_traces` to get specific trace IDs
+4. **Compare Traces**: Run triage analysis comparing baseline vs anomaly
+5. **Deep Dive**: Investigate specific spans and correlate with logs
+
+### For Incident Response:
+1. **Check Metrics**: Query relevant metrics for affected services
+2. **Search Logs**: Look for errors around the incident time
+3. **Find Traces**: Identify traces during the incident window
+4. **Correlate**: Link traces to logs for root cause evidence
+
+### For Debugging Errors:
+1. **Find Error Traces**: Use trace filtering for error status
+2. **Extract Errors**: Analyze error spans and messages
+3. **Get Logs**: Correlate logs with the trace
+4. **Compare**: Check if errors appear in baseline traces
+
+## Output Guidelines
+
+- Be concise and data-driven
+- Include specific trace IDs, timestamps, and metrics
+- Provide confidence levels based on sample sizes
+- Suggest next steps for investigation
+- Format findings clearly with headers and bullet points
+
+## Example Response Format
+
+```
+## Analysis Summary
+
+### Health Overview (Last 24h)
+- **Service A**: 10,245 requests, 2.3% errors, P95: 450ms
+- **Service B**: 45,123 requests, 0.1% errors, P95: 120ms
+
+### Problem Identified
+Service A showing degradation:
+- Error rate increased from 0.8% to 2.3%
+- P95 latency increased from 350ms to 450ms
+- Issue started approximately 14:00 UTC
+
+### Recommended Investigation
+- Baseline: trace_id=abc123 (P50, no errors)
+- Anomaly: trace_id=xyz789 (P99, ERROR status)
+
+### Next Steps
+1. Compare the two traces for structural differences
+2. Check logs for Service A around 14:00 UTC
+```
+"""

--- a/sre_agent/schema.py
+++ b/sre_agent/schema.py
@@ -1,0 +1,302 @@
+"""Pydantic schemas for SRE Agent structured outputs.
+
+This module defines Pydantic schemas for:
+- Individual findings (LatencyDiff, ErrorDiff, StructureDiff)
+- Sub-agent output reports (LatencyAnalysisReport, ErrorAnalysisReport, etc.)
+- Aggregate report (TraceComparisonReport)
+- Statistical analysis outputs
+- Observability data structures (logs, metrics, errors)
+"""
+
+from enum import Enum
+from typing import Literal
+
+from pydantic import BaseModel, Field
+
+
+class Severity(str, Enum):
+    """Severity level for findings."""
+
+    CRITICAL = "critical"
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+    INFO = "info"
+
+
+class Confidence(str, Enum):
+    """Confidence level for analysis conclusions."""
+
+    HIGH = "high"
+    MEDIUM = "medium"
+    LOW = "low"
+
+
+# =============================================================================
+# Trace Analysis Schemas
+# =============================================================================
+
+
+class SpanInfo(BaseModel):
+    """Information about a single span in a trace."""
+
+    span_id: str = Field(description="Unique identifier for the span")
+    name: str = Field(description="Name/operation of the span")
+    duration_ms: float | None = Field(
+        default=None, description="Duration in milliseconds"
+    )
+    parent_span_id: str | None = Field(
+        default=None, description="Parent span ID if nested"
+    )
+    has_error: bool = Field(default=False, description="Whether this span has errors")
+    labels: dict[str, str] = Field(
+        default_factory=dict, description="Span labels/attributes"
+    )
+
+
+class LatencyDiff(BaseModel):
+    """Latency difference for a specific span type."""
+
+    span_name: str = Field(description="Name of the span being compared")
+    baseline_ms: float = Field(description="Duration in baseline trace (ms)")
+    target_ms: float = Field(description="Duration in target trace (ms)")
+    diff_ms: float = Field(description="Difference in milliseconds")
+    diff_percent: float = Field(description="Percentage change")
+    severity: Severity = Field(description="Impact severity")
+
+
+class ErrorDiff(BaseModel):
+    """Error difference between traces."""
+
+    span_name: str = Field(description="Span where the error occurred")
+    error_type: str = Field(description="Type or category of error")
+    error_message: str | None = Field(default=None, description="Error message")
+    status_code: int | str | None = Field(default=None, description="Status code")
+    is_new: bool = Field(description="True if this error is new")
+
+
+class StructureDiff(BaseModel):
+    """Structural difference in the call graph."""
+
+    change_type: Literal["added", "removed", "modified"] = Field(
+        description="Type of structural change"
+    )
+    span_name: str = Field(description="Name of the affected span")
+    description: str = Field(description="Description of the structural change")
+
+
+class TraceSummary(BaseModel):
+    """Summary information for a single trace."""
+
+    trace_id: str = Field(description="Unique trace identifier")
+    span_count: int = Field(description="Total number of spans")
+    total_duration_ms: float = Field(description="Total trace duration in ms")
+    error_count: int = Field(default=0, description="Number of error spans")
+    max_depth: int = Field(default=0, description="Maximum call tree depth")
+
+
+class TraceComparisonReport(BaseModel):
+    """Complete trace comparison analysis report."""
+
+    baseline_summary: TraceSummary = Field(description="Summary of baseline trace")
+    target_summary: TraceSummary = Field(description="Summary of target trace")
+    overall_assessment: Literal["healthy", "degraded", "critical"] = Field(
+        description="Overall health assessment"
+    )
+    latency_findings: list[LatencyDiff] = Field(default_factory=list)
+    error_findings: list[ErrorDiff] = Field(default_factory=list)
+    structure_findings: list[StructureDiff] = Field(default_factory=list)
+    root_cause_hypothesis: str = Field(description="Root cause hypothesis")
+    recommendations: list[str] = Field(default_factory=list)
+
+
+# =============================================================================
+# Sub-Agent Output Schemas
+# =============================================================================
+
+
+class LatencyAnalysisReport(BaseModel):
+    """Output schema for the latency_analyzer sub-agent."""
+
+    baseline_trace_id: str
+    target_trace_id: str
+    overall_diff_ms: float
+    top_slowdowns: list[LatencyDiff] = Field(default_factory=list)
+    improvements: list[LatencyDiff] = Field(default_factory=list)
+    root_cause_hypothesis: str
+
+
+class ErrorInfo(BaseModel):
+    """Detailed information about an error occurrence."""
+
+    span_name: str
+    error_type: str
+    status_code: int | str | None = None
+    error_message: str | None = None
+    service_name: str | None = None
+
+
+class ErrorAnalysisReport(BaseModel):
+    """Output schema for the error_analyzer sub-agent."""
+
+    baseline_error_count: int
+    target_error_count: int
+    net_change: int
+    new_errors: list[ErrorInfo] = Field(default_factory=list)
+    resolved_errors: list[ErrorInfo] = Field(default_factory=list)
+    common_errors: list[ErrorInfo] = Field(default_factory=list)
+    error_pattern_analysis: str
+    recommendations: list[str] = Field(default_factory=list)
+
+
+class StructuralChange(BaseModel):
+    """A single structural change in the call graph."""
+
+    change_type: Literal["added", "removed", "depth_change", "fanout_change"]
+    span_name: str
+    description: str
+    possible_reason: str | None = None
+
+
+class StructureAnalysisReport(BaseModel):
+    """Output schema for the structure_analyzer sub-agent."""
+
+    baseline_span_count: int
+    baseline_depth: int
+    target_span_count: int
+    target_depth: int
+    missing_operations: list[StructuralChange] = Field(default_factory=list)
+    new_operations: list[StructuralChange] = Field(default_factory=list)
+    call_pattern_changes: list[str] = Field(default_factory=list)
+    behavioral_impact: str
+
+
+class LatencyDistribution(BaseModel):
+    """Statistical distribution of latency values."""
+
+    sample_size: int
+    mean_ms: float
+    median_ms: float
+    p90_ms: float
+    p95_ms: float
+    p99_ms: float
+    std_dev_ms: float
+    coefficient_of_variation: float
+
+
+class AnomalyFinding(BaseModel):
+    """A span identified as anomalous via statistical analysis."""
+
+    span_name: str
+    observed_ms: float
+    expected_ms: float
+    z_score: float
+    severity: Severity
+
+
+class CriticalPathSegment(BaseModel):
+    """A segment of the critical path through a trace."""
+
+    span_name: str
+    duration_ms: float
+    percentage_of_total: float
+    is_optimization_target: bool = False
+
+
+class StatisticalAnalysisReport(BaseModel):
+    """Output schema for the statistics_analyzer sub-agent."""
+
+    latency_distribution: LatencyDistribution
+    anomaly_threshold: float
+    anomalies: list[AnomalyFinding] = Field(default_factory=list)
+    critical_path: list[CriticalPathSegment] = Field(default_factory=list)
+    optimization_opportunities: list[str] = Field(default_factory=list)
+
+
+class RootCauseCandidate(BaseModel):
+    """A candidate root cause identified by causal analysis."""
+
+    rank: int
+    span_name: str
+    slowdown_ms: float
+    confidence: Confidence
+    reasoning: str
+
+
+class CausalChainLink(BaseModel):
+    """A link in the causal chain showing issue propagation."""
+
+    span_name: str
+    effect_type: Literal["root_cause", "direct_effect", "cascaded_effect"]
+    latency_contribution_ms: float
+
+
+class CausalAnalysisReport(BaseModel):
+    """Output schema for the causality_analyzer sub-agent."""
+
+    causal_chain: list[CausalChainLink] = Field(default_factory=list)
+    root_cause_candidates: list[RootCauseCandidate] = Field(default_factory=list)
+    propagation_depth: int = 0
+    primary_root_cause: str
+    confidence: Confidence
+    conclusion: str
+    recommended_actions: list[str] = Field(default_factory=list)
+
+
+class ServiceImpact(BaseModel):
+    """Impact assessment for a single service."""
+
+    service_name: str
+    impact_type: Literal["latency", "error_rate", "throughput", "availability"]
+    severity: Severity
+    baseline_value: float
+    current_value: float
+    change_percent: float
+    affected_operations: list[str] = Field(default_factory=list)
+
+
+class ServiceImpactReport(BaseModel):
+    """Output schema for the service_impact sub-agent."""
+
+    total_services_analyzed: int
+    impacted_services_count: int
+    service_impacts: list[ServiceImpact] = Field(default_factory=list)
+    cross_service_effects: list[str] = Field(default_factory=list)
+    blast_radius_assessment: str
+
+
+# =============================================================================
+# Observability Data Schemas
+# =============================================================================
+
+
+class LogEntry(BaseModel):
+    """Represents a single log entry from Cloud Logging."""
+
+    timestamp: str
+    severity: str
+    payload: str
+    resource: dict
+
+
+class TimeSeriesPoint(BaseModel):
+    """Represents a single point in a time series."""
+
+    timestamp: str
+    value: float
+
+
+class TimeSeries(BaseModel):
+    """Represents a time series from Cloud Monitoring."""
+
+    metric: dict
+    resource: dict
+    points: list[TimeSeriesPoint]
+
+
+class ErrorEvent(BaseModel):
+    """Represents an error event from Cloud Error Reporting."""
+
+    event_time: str
+    message: str
+    service_context: dict

--- a/sre_agent/sub_agents/__init__.py
+++ b/sre_agent/sub_agents/__init__.py
@@ -1,0 +1,33 @@
+"""Sub-agents for specialized SRE analysis tasks.
+
+This module provides specialized sub-agents for trace analysis:
+
+Trace Analysis Sub-agents:
+    - aggregate_analyzer: BigQuery-powered aggregate analysis
+    - latency_analyzer: Span timing comparison
+    - error_analyzer: Error detection and comparison
+    - structure_analyzer: Call graph topology analysis
+    - statistics_analyzer: Statistical outlier detection
+    - causality_analyzer: Root cause determination
+    - service_impact_analyzer: Blast radius assessment
+"""
+
+from .trace_analysis import (
+    aggregate_analyzer,
+    latency_analyzer,
+    error_analyzer,
+    structure_analyzer,
+    statistics_analyzer,
+    causality_analyzer,
+    service_impact_analyzer,
+)
+
+__all__ = [
+    "aggregate_analyzer",
+    "latency_analyzer",
+    "error_analyzer",
+    "structure_analyzer",
+    "statistics_analyzer",
+    "causality_analyzer",
+    "service_impact_analyzer",
+]

--- a/sre_agent/sub_agents/trace_analysis/__init__.py
+++ b/sre_agent/sub_agents/trace_analysis/__init__.py
@@ -1,0 +1,37 @@
+"""Trace analysis sub-agents for distributed trace investigation.
+
+This module provides 7 specialized sub-agents organized in 3 stages:
+
+Stage 0 - Aggregate Analysis:
+    - aggregate_analyzer: BigQuery-powered analysis of thousands of traces
+
+Stage 1 - Triage (parallel):
+    - latency_analyzer: Span timing comparison
+    - error_analyzer: Error detection and comparison
+    - structure_analyzer: Call graph topology analysis
+    - statistics_analyzer: Statistical outlier detection
+
+Stage 2 - Deep Dive (parallel):
+    - causality_analyzer: Root cause determination
+    - service_impact_analyzer: Blast radius assessment
+"""
+
+from .agents import (
+    aggregate_analyzer,
+    latency_analyzer,
+    error_analyzer,
+    structure_analyzer,
+    statistics_analyzer,
+    causality_analyzer,
+    service_impact_analyzer,
+)
+
+__all__ = [
+    "aggregate_analyzer",
+    "latency_analyzer",
+    "error_analyzer",
+    "structure_analyzer",
+    "statistics_analyzer",
+    "causality_analyzer",
+    "service_impact_analyzer",
+]

--- a/sre_agent/sub_agents/trace_analysis/agents.py
+++ b/sre_agent/sub_agents/trace_analysis/agents.py
@@ -1,0 +1,257 @@
+"""Trace analysis sub-agents for the SRE Agent.
+
+These sub-agents work together in a multi-stage pipeline:
+- Stage 0: Aggregate analysis (BigQuery)
+- Stage 1: Triage (4 parallel analyzers)
+- Stage 2: Deep dive (2 parallel analyzers)
+"""
+
+from google.adk.agents import LlmAgent
+
+from ...tools import (
+    # Trace tools
+    fetch_trace,
+    calculate_span_durations,
+    extract_errors,
+    build_call_graph,
+    compare_span_timings,
+    find_structural_differences,
+    # BigQuery tools
+    analyze_aggregate_metrics,
+    find_exemplar_traces,
+    compare_time_periods,
+    detect_trend_changes,
+    correlate_logs_with_trace,
+)
+
+# =============================================================================
+# Prompts
+# =============================================================================
+
+AGGREGATE_ANALYZER_PROMPT = """
+Role: You are the **Data Analyst** - The Big Picture Expert.
+
+Your mission is to analyze trace data at scale using BigQuery to identify trends,
+patterns, and anomalies BEFORE diving into individual traces.
+
+Core Responsibilities:
+1. **Broad Analysis First**: Use BigQuery to analyze thousands of traces
+2. **Identify Patterns**: Find which services, operations, or time periods are affected
+3. **Detect Trends**: Determine when issues started and if they're getting worse
+4. **Select Exemplars**: Choose representative traces for detailed investigation
+
+Available Tools:
+- `analyze_aggregate_metrics`: Get service-level health metrics
+- `find_exemplar_traces`: Find specific trace IDs (baseline, outliers, errors)
+- `compare_time_periods`: Compare metrics between two time periods
+- `detect_trend_changes`: Find when performance degraded
+- `correlate_logs_with_trace`: Find related logs
+
+Workflow:
+1. **Start Broad**: Use analyze_aggregate_metrics to understand overall health
+2. **Identify Hot Spots**: Find services or operations with high error rates or latency
+3. **Time Analysis**: Use detect_trend_changes to pinpoint when issues started
+4. **Select Exemplars**: Use find_exemplar_traces to get specific trace IDs
+5. **Summarize**: Provide clear metrics and recommend which traces to investigate
+
+Output Format:
+- **Health Overview**: Request counts, error rates, latency percentiles by service
+- **Problem Areas**: Which services/operations need investigation
+- **Timeline**: When did issues start? Are they getting worse?
+- **Recommended Traces**: Specific trace IDs for baseline and anomaly comparison
+"""
+
+LATENCY_ANALYZER_PROMPT = """
+Role: You are the **Latency Specialist** - The Timing Expert.
+
+Your mission is to compare span timings between traces to identify slowdowns.
+
+Focus Areas:
+1. **Duration Comparison**: Which spans got slower or faster?
+2. **Pattern Detection**: N+1 queries, serial chains, bottlenecks
+3. **Critical Path**: Which spans contribute most to total latency?
+
+Available Tools:
+- `fetch_trace`: Get full trace data
+- `calculate_span_durations`: Extract timing for all spans
+- `compare_span_timings`: Compare timings between two traces
+
+Output Format:
+- List spans that got significantly slower (>10% or >50ms)
+- Identify any detected anti-patterns (N+1, serial chains)
+- Highlight the critical path and bottlenecks
+"""
+
+ERROR_ANALYZER_PROMPT = """
+Role: You are the **Error Forensics Expert** - The Failure Detective.
+
+Your mission is to detect and compare errors between traces.
+
+Focus Areas:
+1. **Error Detection**: Find all error spans in the target trace
+2. **Error Comparison**: Which errors are new vs existing?
+3. **Error Patterns**: HTTP 5xx, gRPC errors, exceptions
+
+Available Tools:
+- `fetch_trace`: Get full trace data
+- `extract_errors`: Find all error spans with details
+
+Output Format:
+- List all errors found (span, type, message, status code)
+- Compare errors between baseline and target
+- Categorize errors by type (HTTP, gRPC, application)
+"""
+
+STRUCTURE_ANALYZER_PROMPT = """
+Role: You are the **Structure Mapper** - The Topology Expert.
+
+Your mission is to compare call graph structures between traces.
+
+Focus Areas:
+1. **Structural Changes**: Missing or new spans
+2. **Depth Changes**: Did the call tree get deeper or shallower?
+3. **Fan-out Changes**: More or fewer downstream calls?
+
+Available Tools:
+- `fetch_trace`: Get full trace data
+- `build_call_graph`: Build hierarchical call graph
+- `find_structural_differences`: Compare structures
+
+Output Format:
+- List missing spans (in baseline but not target)
+- List new spans (in target but not baseline)
+- Report depth and span count changes
+"""
+
+STATISTICS_ANALYZER_PROMPT = """
+Role: You are the **Statistics Analyst** - The Quant Expert.
+
+Your mission is to determine if observed differences are statistically significant.
+
+Focus Areas:
+1. **Anomaly Detection**: Is the target trace an outlier?
+2. **Z-Score Analysis**: How many standard deviations from mean?
+3. **Percentile Ranking**: Where does this trace fall in the distribution?
+
+Available Tools:
+- `fetch_trace`: Get full trace data
+- `calculate_span_durations`: Get timing data for statistical analysis
+
+Output Format:
+- Report percentile ranking of the trace
+- Calculate z-scores for key metrics
+- Determine if differences are statistically significant
+"""
+
+CAUSALITY_ANALYZER_PROMPT = """
+Role: You are the **Root Cause Analyst** - The Causality Expert.
+
+Your mission is to determine WHY the issue occurred based on triage findings.
+
+Focus Areas:
+1. **Root Cause**: What is the primary cause of the issue?
+2. **Causal Chain**: What sequence of events led to the problem?
+3. **Evidence**: What data supports your conclusion?
+
+Available Tools:
+- `fetch_trace`: Get full trace data
+- `build_call_graph`: Understand call hierarchy
+- `correlate_logs_with_trace`: Find related logs for evidence
+
+Output Format:
+- State the root cause with confidence level
+- Describe the causal chain of events
+- List supporting evidence from traces and logs
+"""
+
+SERVICE_IMPACT_ANALYZER_PROMPT = """
+Role: You are the **Impact Assessor** - The Blast Radius Expert.
+
+Your mission is to determine the scope and impact of the issue.
+
+Focus Areas:
+1. **Affected Services**: Which services are impacted?
+2. **User Impact**: How does this affect end users?
+3. **Blast Radius**: How widespread is the problem?
+
+Available Tools:
+- `fetch_trace`: Get full trace data
+- `build_call_graph`: Map service dependencies
+
+Output Format:
+- List all affected services
+- Describe user impact (latency, errors, failures)
+- Assess blast radius (isolated, moderate, widespread)
+"""
+
+# =============================================================================
+# Sub-Agent Definitions
+# =============================================================================
+
+# Stage 0: Aggregate Analyzer
+aggregate_analyzer = LlmAgent(
+    name="aggregate_analyzer",
+    model="gemini-2.5-pro",
+    description=(
+        "Analyzes trace data at scale using BigQuery to identify trends, patterns, "
+        "and select exemplar traces for investigation."
+    ),
+    instruction=AGGREGATE_ANALYZER_PROMPT,
+    tools=[
+        analyze_aggregate_metrics,
+        find_exemplar_traces,
+        compare_time_periods,
+        detect_trend_changes,
+        correlate_logs_with_trace,
+    ],
+)
+
+# Stage 1: Triage Analyzers
+latency_analyzer = LlmAgent(
+    name="latency_analyzer",
+    model="gemini-2.5-pro",
+    description="Analyzes and compares span latencies between traces.",
+    instruction=LATENCY_ANALYZER_PROMPT,
+    tools=[fetch_trace, calculate_span_durations, compare_span_timings],
+)
+
+error_analyzer = LlmAgent(
+    name="error_analyzer",
+    model="gemini-2.5-pro",
+    description="Detects and compares errors between traces.",
+    instruction=ERROR_ANALYZER_PROMPT,
+    tools=[fetch_trace, extract_errors],
+)
+
+structure_analyzer = LlmAgent(
+    name="structure_analyzer",
+    model="gemini-2.5-pro",
+    description="Compares call graph structures between traces.",
+    instruction=STRUCTURE_ANALYZER_PROMPT,
+    tools=[fetch_trace, build_call_graph, find_structural_differences],
+)
+
+statistics_analyzer = LlmAgent(
+    name="statistics_analyzer",
+    model="gemini-2.5-pro",
+    description="Performs statistical analysis to detect anomalies.",
+    instruction=STATISTICS_ANALYZER_PROMPT,
+    tools=[fetch_trace, calculate_span_durations],
+)
+
+# Stage 2: Deep Dive Analyzers
+causality_analyzer = LlmAgent(
+    name="causality_analyzer",
+    model="gemini-2.5-pro",
+    description="Determines root cause based on triage findings.",
+    instruction=CAUSALITY_ANALYZER_PROMPT,
+    tools=[fetch_trace, build_call_graph, correlate_logs_with_trace],
+)
+
+service_impact_analyzer = LlmAgent(
+    name="service_impact_analyzer",
+    model="gemini-2.5-pro",
+    description="Assesses blast radius and service impact.",
+    instruction=SERVICE_IMPACT_ANALYZER_PROMPT,
+    tools=[fetch_trace, build_call_graph],
+)

--- a/sre_agent/tools/__init__.py
+++ b/sre_agent/tools/__init__.py
@@ -1,0 +1,157 @@
+"""SRE Agent Tools - Modular tooling for Google Cloud Observability.
+
+This module provides a comprehensive set of tools for SRE tasks:
+
+GCP Tools (tools.gcp):
+    - BigQuery MCP for SQL-based data analysis
+    - Cloud Logging MCP and direct API for log queries
+    - Cloud Monitoring MCP and direct API for metrics
+    - Error Reporting for error analysis
+
+BigQuery Tools (tools.bigquery):
+    - OpenTelemetry schema analysis tools
+    - Aggregate metrics analysis
+    - Exemplar trace selection
+    - Time period comparison
+    - Trend detection
+    - Log correlation
+
+Trace Tools (tools.trace):
+    - Cloud Trace API clients for fetching traces
+    - Trace analysis utilities (durations, errors, call graphs)
+    - Trace comparison tools for diff analysis
+    - Trace filter utilities
+
+Common Utilities (tools.common):
+    - @adk_tool decorator with OpenTelemetry instrumentation
+    - Telemetry helpers (tracer, meter)
+    - Thread-safe caching for API responses
+
+Usage:
+    from sre_agent.tools import fetch_trace, list_traces
+    from sre_agent.tools.gcp import mcp_list_log_entries
+    from sre_agent.tools.trace import compare_span_timings
+    from sre_agent.tools.bigquery import analyze_aggregate_metrics
+"""
+
+# Common utilities
+from .common import (
+    adk_tool,
+    get_tracer,
+    get_meter,
+    log_tool_call,
+    DataCache,
+    get_data_cache,
+)
+
+# GCP tools
+from .gcp import (
+    # MCP toolset factories
+    create_bigquery_mcp_toolset,
+    create_logging_mcp_toolset,
+    create_monitoring_mcp_toolset,
+    call_mcp_tool_with_retry,
+    get_project_id_with_fallback,
+    # MCP tools
+    mcp_list_log_entries,
+    mcp_list_timeseries,
+    mcp_query_range,
+    # Direct API tools
+    list_log_entries,
+    list_time_series,
+    list_error_events,
+    get_logs_for_trace,
+    get_current_time,
+)
+
+# Trace tools
+from .trace import (
+    # API clients
+    fetch_trace,
+    fetch_trace_data,
+    list_traces,
+    find_example_traces,
+    get_trace_by_url,
+    validate_trace,
+    # Analysis
+    calculate_span_durations,
+    extract_errors,
+    build_call_graph,
+    summarize_trace,
+    validate_trace_quality,
+    # Comparison
+    compare_span_timings,
+    find_structural_differences,
+    # Filters
+    TraceQueryBuilder,
+    TraceSelector,
+    build_trace_filter,
+    select_traces_from_error_reports,
+    select_traces_from_monitoring_alerts,
+    select_traces_from_statistical_outliers,
+    select_traces_manually,
+)
+
+# BigQuery tools
+from .bigquery import (
+    analyze_aggregate_metrics,
+    find_exemplar_traces,
+    compare_time_periods,
+    detect_trend_changes,
+    correlate_logs_with_trace,
+)
+
+__all__ = [
+    # Common
+    "adk_tool",
+    "get_tracer",
+    "get_meter",
+    "log_tool_call",
+    "DataCache",
+    "get_data_cache",
+    # GCP MCP
+    "create_bigquery_mcp_toolset",
+    "create_logging_mcp_toolset",
+    "create_monitoring_mcp_toolset",
+    "call_mcp_tool_with_retry",
+    "get_project_id_with_fallback",
+    "mcp_list_log_entries",
+    "mcp_list_timeseries",
+    "mcp_query_range",
+    # GCP Direct API
+    "list_log_entries",
+    "list_time_series",
+    "list_error_events",
+    "get_logs_for_trace",
+    "get_current_time",
+    # Trace API
+    "fetch_trace",
+    "fetch_trace_data",
+    "list_traces",
+    "find_example_traces",
+    "get_trace_by_url",
+    "validate_trace",
+    # Trace Analysis
+    "calculate_span_durations",
+    "extract_errors",
+    "build_call_graph",
+    "summarize_trace",
+    "validate_trace_quality",
+    # Trace Comparison
+    "compare_span_timings",
+    "find_structural_differences",
+    # Trace Filters
+    "TraceQueryBuilder",
+    "TraceSelector",
+    "build_trace_filter",
+    "select_traces_from_error_reports",
+    "select_traces_from_monitoring_alerts",
+    "select_traces_from_statistical_outliers",
+    "select_traces_manually",
+    # BigQuery
+    "analyze_aggregate_metrics",
+    "find_exemplar_traces",
+    "compare_time_periods",
+    "detect_trend_changes",
+    "correlate_logs_with_trace",
+]

--- a/sre_agent/tools/bigquery/__init__.py
+++ b/sre_agent/tools/bigquery/__init__.py
@@ -1,0 +1,28 @@
+"""BigQuery tools for SRE Agent.
+
+This module provides BigQuery-powered analysis tools, particularly for
+OpenTelemetry trace and log data exported to BigQuery.
+
+Tools:
+    - analyze_aggregate_metrics: Aggregate metrics analysis
+    - find_exemplar_traces: Find representative traces
+    - compare_time_periods: Compare before/after metrics
+    - detect_trend_changes: Time series trend analysis
+    - correlate_logs_with_trace: Log correlation for root cause
+"""
+
+from .otel import (
+    analyze_aggregate_metrics,
+    find_exemplar_traces,
+    compare_time_periods,
+    detect_trend_changes,
+    correlate_logs_with_trace,
+)
+
+__all__ = [
+    "analyze_aggregate_metrics",
+    "find_exemplar_traces",
+    "compare_time_periods",
+    "detect_trend_changes",
+    "correlate_logs_with_trace",
+]

--- a/sre_agent/tools/bigquery/otel.py
+++ b/sre_agent/tools/bigquery/otel.py
@@ -1,0 +1,606 @@
+"""BigQuery-powered tools for OpenTelemetry data analysis.
+
+This module provides sophisticated analysis capabilities using BigQuery
+to query trace and log data at scale. It assumes data is exported to BigQuery
+using the OpenTelemetry schema.
+
+Google Cloud Observability OpenTelemetry schema (_AllSpans table):
+- Table: `<dataset>._AllSpans` (or custom table name)
+- Key fields:
+  - trace_id: Unique trace identifier (128-bit hex string)
+  - span_id: Unique span identifier (64-bit hex string)
+  - parent_span_id: Parent span reference (NULL for root spans)
+  - name: Span/operation name
+  - start_time: Span start timestamp
+  - end_time: Span end timestamp
+  - duration_nano: Span duration in nanoseconds
+  - status: RECORD with code (0=UNSET, 1=OK, 2=ERROR) and message
+  - kind: Span kind (1=INTERNAL, 2=SERVER, 3=CLIENT, 4=PRODUCER, 5=CONSUMER)
+  - attributes: JSON key-value pairs
+  - resource: RECORD with attributes (service.name, host.name, etc.)
+"""
+
+import json
+import logging
+
+from ..common import adk_tool
+
+logger = logging.getLogger(__name__)
+
+
+@adk_tool
+def analyze_aggregate_metrics(
+    dataset_id: str,
+    table_name: str,
+    time_window_hours: int = 24,
+    service_name: str | None = None,
+    operation_name: str | None = None,
+    min_duration_ms: float | None = None,
+    group_by: str = "service_name",
+) -> str:
+    """
+    Performs broad aggregate analysis of trace data using BigQuery.
+
+    This is the first step in SRE analysis: get the big picture before drilling down.
+    Analyzes metrics like request rate, error rate, latency percentiles across services.
+
+    Args:
+        dataset_id: BigQuery dataset ID (e.g., 'my_project.telemetry')
+        table_name: Table name containing OTEL traces
+        time_window_hours: How many hours back to analyze
+        service_name: Optional filter for specific service
+        operation_name: Optional filter for specific operation
+        min_duration_ms: Optional filter for minimum duration
+        group_by: How to group results (service_name, operation_name, status_code)
+
+    Returns:
+        JSON with SQL query and metadata for execution via BigQuery MCP.
+    """
+    where_conditions = [
+        f"start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {time_window_hours} HOUR)",
+        "parent_span_id IS NULL  -- Root spans only for aggregate metrics",
+    ]
+
+    if service_name:
+        where_conditions.append(
+            f"JSON_EXTRACT_SCALAR(resource.attributes, '$.service.name') = '{service_name}'"
+        )
+
+    if operation_name:
+        where_conditions.append(f"name = '{operation_name}'")
+
+    if min_duration_ms:
+        min_duration_ns = int(min_duration_ms * 1_000_000)
+        where_conditions.append(f"duration_nano >= {min_duration_ns}")
+
+    where_clause = " AND ".join(where_conditions)
+
+    group_by_field = group_by
+    if group_by == "service_name":
+        group_by_field = "JSON_EXTRACT_SCALAR(resource.attributes, '$.service.name')"
+    elif group_by == "operation_name":
+        group_by_field = "name"
+    elif group_by == "status_code":
+        group_by_field = "status.code"
+
+    query = f"""
+SELECT
+  {group_by_field} as {group_by},
+  COUNT(*) as request_count,
+  COUNTIF(status.code = 2) as error_count,
+  ROUND(COUNTIF(status.code = 2) / COUNT(*) * 100, 2) as error_rate_pct,
+  ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(50)], 2) as p50_ms,
+  ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(95)], 2) as p95_ms,
+  ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(99)], 2) as p99_ms,
+  ROUND(AVG(duration_nano / 1000000), 2) as avg_duration_ms,
+  MIN(start_time) as first_seen,
+  MAX(start_time) as last_seen
+FROM `{dataset_id}.{table_name}`
+WHERE {where_clause}
+GROUP BY {group_by}
+ORDER BY error_rate_pct DESC, p99_ms DESC
+LIMIT 50
+"""
+
+    logger.info(f"Generated Aggregate Analysis SQL:\n{query.strip()}")
+
+    return json.dumps(
+        {
+            "analysis_type": "aggregate_metrics",
+            "sql_query": query.strip(),
+            "description": f"Aggregate metrics grouped by {group_by} for last {time_window_hours}h",
+            "next_steps": [
+                "Execute this query using BigQuery MCP execute_sql tool",
+                "Review services with high error rates or P99 latency",
+                "Use find_exemplar_traces to get specific trace IDs for investigation",
+            ],
+        }
+    )
+
+
+@adk_tool
+def find_exemplar_traces(
+    dataset_id: str,
+    table_name: str,
+    time_window_hours: int = 24,
+    service_name: str | None = None,
+    operation_name: str | None = None,
+    selection_strategy: str = "outliers",
+    limit: int = 10,
+) -> str:
+    """
+    Finds exemplar traces using BigQuery for detailed investigation.
+
+    Args:
+        dataset_id: BigQuery dataset ID
+        table_name: Table name containing OTEL traces
+        time_window_hours: How many hours back to search
+        service_name: Optional filter for specific service
+        operation_name: Optional filter for specific operation
+        selection_strategy: How to select exemplars:
+            - 'outliers': Slowest traces (P99+)
+            - 'errors': Traces with errors
+            - 'baseline': Typical traces (P50)
+            - 'comparison': Both baseline and outliers
+        limit: Number of exemplars to return
+
+    Returns:
+        JSON with SQL query to find exemplar trace IDs.
+    """
+    where_conditions = [
+        f"start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {time_window_hours} HOUR)",
+        "parent_span_id IS NULL",
+    ]
+
+    if service_name:
+        where_conditions.append(
+            f"JSON_EXTRACT_SCALAR(resource.attributes, '$.service.name') = '{service_name}'"
+        )
+
+    if operation_name:
+        where_conditions.append(f"name = '{operation_name}'")
+
+    where_clause = " AND ".join(where_conditions)
+
+    if selection_strategy == "outliers":
+        query = f"""
+WITH duration_stats AS (
+  SELECT
+    APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(95)] as p95_ms
+  FROM `{dataset_id}.{table_name}`
+  WHERE {where_clause}
+)
+SELECT
+  t.trace_id,
+  t.name as operation,
+  JSON_EXTRACT_SCALAR(t.resource.attributes, '$.service.name') as service_name,
+  ROUND(t.duration_nano / 1000000, 2) as duration_ms,
+  t.status.code as status_code,
+  t.start_time,
+  ROUND((t.duration_nano / 1000000 - s.p95_ms) / s.p95_ms * 100, 2) as pct_above_p95
+FROM `{dataset_id}.{table_name}` t
+CROSS JOIN duration_stats s
+WHERE {where_clause}
+  AND t.duration_nano / 1000000 >= s.p95_ms
+ORDER BY t.duration_nano DESC
+LIMIT {limit}
+"""
+
+    elif selection_strategy == "errors":
+        query = f"""
+SELECT
+  trace_id,
+  name as operation,
+  JSON_EXTRACT_SCALAR(resource.attributes, '$.service.name') as service_name,
+  ROUND(duration_nano / 1000000, 2) as duration_ms,
+  status.code as status_code,
+  status.message as error_message,
+  start_time,
+  'error_trace' as selection_reason
+FROM `{dataset_id}.{table_name}`
+WHERE {where_clause}
+  AND status.code = 2  -- ERROR
+ORDER BY start_time DESC
+LIMIT {limit}
+"""
+
+    elif selection_strategy == "baseline":
+        query = f"""
+WITH duration_stats AS (
+  SELECT
+    APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(50)] as p50_ms
+  FROM `{dataset_id}.{table_name}`
+  WHERE {where_clause}
+)
+SELECT
+  t.trace_id,
+  t.name as operation,
+  JSON_EXTRACT_SCALAR(t.resource.attributes, '$.service.name') as service_name,
+  ROUND(t.duration_nano / 1000000, 2) as duration_ms,
+  t.status.code as status_code,
+  t.start_time,
+  'baseline_p50' as selection_reason
+FROM `{dataset_id}.{table_name}` t
+CROSS JOIN duration_stats s
+WHERE {where_clause}
+  AND t.status.code != 2  -- Not ERROR
+  AND ABS(t.duration_nano / 1000000 - s.p50_ms) < s.p50_ms * 0.1
+ORDER BY ABS(t.duration_nano / 1000000 - s.p50_ms)
+LIMIT {limit}
+"""
+
+    elif selection_strategy == "comparison":
+        query = f"""
+WITH duration_stats AS (
+  SELECT
+    APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(50)] as p50_ms,
+    APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(95)] as p95_ms
+  FROM `{dataset_id}.{table_name}`
+  WHERE {where_clause}
+),
+baseline_traces AS (
+  SELECT
+    t.trace_id,
+    t.name as operation,
+    JSON_EXTRACT_SCALAR(t.resource.attributes, '$.service.name') as service_name,
+    ROUND(t.duration_nano / 1000000, 2) as duration_ms,
+    t.status.code as status_code,
+    t.start_time,
+    'baseline_p50' as selection_reason
+  FROM `{dataset_id}.{table_name}` t
+  CROSS JOIN duration_stats s
+  WHERE {where_clause}
+    AND t.status.code != 2
+    AND ABS(t.duration_nano / 1000000 - s.p50_ms) < s.p50_ms * 0.1
+  ORDER BY ABS(t.duration_nano / 1000000 - s.p50_ms)
+  LIMIT {limit // 2}
+),
+outlier_traces AS (
+  SELECT
+    t.trace_id,
+    t.name as operation,
+    JSON_EXTRACT_SCALAR(t.resource.attributes, '$.service.name') as service_name,
+    ROUND(t.duration_nano / 1000000, 2) as duration_ms,
+    t.status.code as status_code,
+    t.start_time,
+    'outlier_p95' as selection_reason
+  FROM `{dataset_id}.{table_name}` t
+  CROSS JOIN duration_stats s
+  WHERE {where_clause}
+    AND t.duration_nano / 1000000 >= s.p95_ms
+  ORDER BY t.duration_nano DESC
+  LIMIT {limit // 2}
+)
+SELECT * FROM baseline_traces
+UNION ALL
+SELECT * FROM outlier_traces
+ORDER BY selection_reason, duration_ms
+"""
+    else:
+        return json.dumps(
+            {"error": f"Unknown selection_strategy: {selection_strategy}"}
+        )
+
+    logger.info(f"Generated Exemplar Selection SQL ({selection_strategy}):\n{query.strip()}")
+
+    return json.dumps(
+        {
+            "analysis_type": "exemplar_selection",
+            "selection_strategy": selection_strategy,
+            "sql_query": query.strip(),
+            "description": f"Find {limit} exemplar traces using '{selection_strategy}' strategy",
+            "next_steps": [
+                "Execute this query using BigQuery MCP execute_sql tool",
+                "Extract trace_id values from results",
+                "Use fetch_trace to get full trace details",
+                "Use run_triage_analysis to compare baseline vs outlier traces",
+            ],
+        }
+    )
+
+
+@adk_tool
+def correlate_logs_with_trace(
+    dataset_id: str,
+    trace_id: str,
+    trace_table_name: str = "_AllSpans",
+    log_table_name: str = "_AllLogs",
+    include_nearby_logs: bool = True,
+    time_window_seconds: int = 30,
+) -> str:
+    """
+    Finds logs correlated with a specific trace for root cause analysis.
+
+    Args:
+        dataset_id: BigQuery dataset ID
+        trace_id: The trace ID to correlate logs with
+        trace_table_name: Table name containing OTEL traces
+        log_table_name: Table name containing OTEL logs
+        include_nearby_logs: If True, include logs from same service around same time
+        time_window_seconds: Time window for nearby logs
+
+    Returns:
+        JSON with SQL query to find correlated logs.
+    """
+    query = f"""
+WITH trace_context AS (
+  SELECT
+    MIN(start_time) as trace_start,
+    MAX(end_time) as trace_end,
+    ANY_VALUE(JSON_EXTRACT_SCALAR(resource.attributes, '$.service.name')) as service_name
+  FROM `{dataset_id}.{trace_table_name}`
+  WHERE trace_id = '{trace_id}'
+    AND parent_span_id IS NULL
+),
+direct_logs AS (
+  SELECT
+    l.time_unix_nano as timestamp,
+    l.severity_text as severity,
+    l.body.string_value as message,
+    JSON_EXTRACT_SCALAR(l.resource.attributes, '$.service.name') as service,
+    'direct_correlation' as correlation_type,
+    l.trace_id
+  FROM `{dataset_id}.{log_table_name}` l
+  WHERE l.trace_id = '{trace_id}'
+)
+"""
+
+    if include_nearby_logs:
+        query += f""",
+nearby_logs AS (
+  SELECT
+    l.time_unix_nano as timestamp,
+    l.severity_text as severity,
+    l.body.string_value as message,
+    JSON_EXTRACT_SCALAR(l.resource.attributes, '$.service.name') as service,
+    'temporal_correlation' as correlation_type,
+    l.trace_id
+  FROM `{dataset_id}.{log_table_name}` l
+  CROSS JOIN trace_context t
+  WHERE JSON_EXTRACT_SCALAR(l.resource.attributes, '$.service.name') = t.service_name
+    AND TIMESTAMP_MICROS(CAST(l.time_unix_nano / 1000 AS INT64)) >= TIMESTAMP_SUB(t.trace_start, INTERVAL {time_window_seconds} SECOND)
+    AND TIMESTAMP_MICROS(CAST(l.time_unix_nano / 1000 AS INT64)) <= TIMESTAMP_ADD(t.trace_end, INTERVAL {time_window_seconds} SECOND)
+    AND l.severity_text IN ('ERROR', 'ERROR2', 'ERROR3', 'ERROR4', 'FATAL', 'WARN')
+    AND (l.trace_id IS NULL OR l.trace_id != '{trace_id}')
+  LIMIT 20
+)
+SELECT * FROM direct_logs
+UNION ALL
+SELECT * FROM nearby_logs
+ORDER BY timestamp
+"""
+    else:
+        query += """
+SELECT * FROM direct_logs
+ORDER BY timestamp
+"""
+
+    logger.info(f"Generated Log Correlation SQL (trace={trace_id}):\n{query.strip()}")
+
+    return json.dumps(
+        {
+            "analysis_type": "log_correlation",
+            "trace_id": trace_id,
+            "sql_query": query.strip(),
+            "description": f"Find logs correlated with trace {trace_id}",
+            "next_steps": [
+                "Execute this query using BigQuery MCP execute_sql tool",
+                "Look for ERROR or WARN severity logs",
+                "Check log messages for exceptions, timeouts, or error codes",
+            ],
+        }
+    )
+
+
+@adk_tool
+def compare_time_periods(
+    dataset_id: str,
+    table_name: str,
+    baseline_hours_ago_start: int = 48,
+    baseline_hours_ago_end: int = 24,
+    anomaly_hours_ago_start: int = 24,
+    anomaly_hours_ago_end: int = 0,
+    service_name: str | None = None,
+    operation_name: str | None = None,
+) -> str:
+    """
+    Compares trace metrics between two time periods to detect degradations.
+
+    Args:
+        dataset_id: BigQuery dataset ID
+        table_name: Table name containing OTEL traces
+        baseline_hours_ago_start: Baseline period start (hours ago)
+        baseline_hours_ago_end: Baseline period end (hours ago)
+        anomaly_hours_ago_start: Anomaly period start (hours ago)
+        anomaly_hours_ago_end: Anomaly period end (hours ago)
+        service_name: Optional filter for specific service
+        operation_name: Optional filter for specific operation
+
+    Returns:
+        JSON with SQL query comparing the two periods.
+    """
+    where_filter = ""
+    if service_name:
+        where_filter += f"AND JSON_EXTRACT_SCALAR(resource.attributes, '$.service.name') = '{service_name}'\n  "
+    if operation_name:
+        where_filter += f"AND name = '{operation_name}'\n  "
+
+    query = f"""
+WITH baseline_period AS (
+  SELECT
+    'baseline' as period,
+    COUNT(*) as request_count,
+    COUNTIF(status.code = 2) as error_count,
+    ROUND(COUNTIF(status.code = 2) / COUNT(*) * 100, 2) as error_rate_pct,
+    ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(50)], 2) as p50_ms,
+    ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(95)], 2) as p95_ms,
+    ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(99)], 2) as p99_ms,
+    ROUND(AVG(duration_nano / 1000000), 2) as avg_ms
+  FROM `{dataset_id}.{table_name}`
+  WHERE start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {baseline_hours_ago_start} HOUR)
+    AND start_time < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {baseline_hours_ago_end} HOUR)
+    AND parent_span_id IS NULL
+    {where_filter}
+),
+anomaly_period AS (
+  SELECT
+    'anomaly' as period,
+    COUNT(*) as request_count,
+    COUNTIF(status.code = 2) as error_count,
+    ROUND(COUNTIF(status.code = 2) / COUNT(*) * 100, 2) as error_rate_pct,
+    ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(50)], 2) as p50_ms,
+    ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(95)], 2) as p95_ms,
+    ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(99)], 2) as p99_ms,
+    ROUND(AVG(duration_nano / 1000000), 2) as avg_ms
+  FROM `{dataset_id}.{table_name}`
+  WHERE start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {anomaly_hours_ago_start} HOUR)
+    AND start_time < TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {anomaly_hours_ago_end} HOUR)
+    AND parent_span_id IS NULL
+    {where_filter}
+),
+combined AS (
+  SELECT * FROM baseline_period
+  UNION ALL
+  SELECT * FROM anomaly_period
+)
+SELECT
+  period,
+  request_count,
+  error_count,
+  error_rate_pct,
+  p50_ms,
+  p95_ms,
+  p99_ms,
+  avg_ms,
+  LAG(p95_ms) OVER (ORDER BY period) as baseline_p95_ms,
+  p95_ms - LAG(p95_ms) OVER (ORDER BY period) as p95_delta_ms,
+  ROUND((p95_ms - LAG(p95_ms) OVER (ORDER BY period)) / LAG(p95_ms) OVER (ORDER BY period) * 100, 1) as p95_change_pct,
+  error_rate_pct - LAG(error_rate_pct) OVER (ORDER BY period) as error_rate_delta
+FROM combined
+ORDER BY period
+"""
+
+    logger.info(f"Generated Time Period Comparison SQL:\n{query.strip()}")
+
+    return json.dumps(
+        {
+            "analysis_type": "time_period_comparison",
+            "sql_query": query.strip(),
+            "baseline_period": f"{baseline_hours_ago_start}h ago to {baseline_hours_ago_end}h ago",
+            "anomaly_period": f"{anomaly_hours_ago_start}h ago to {anomaly_hours_ago_end}h ago",
+            "description": "Compare metrics between baseline and anomaly time periods",
+            "next_steps": [
+                "Execute this query using BigQuery MCP execute_sql tool",
+                "Look for significant deltas in p95_change_pct or error_rate_delta",
+                "If degradation is confirmed, use find_exemplar_traces for each period",
+            ],
+        }
+    )
+
+
+@adk_tool
+def detect_trend_changes(
+    dataset_id: str,
+    table_name: str,
+    time_window_hours: int = 72,
+    bucket_hours: int = 1,
+    service_name: str | None = None,
+    metric: str = "p95",
+) -> str:
+    """
+    Detects when performance trends changed using time-series analysis.
+
+    Args:
+        dataset_id: BigQuery dataset ID
+        table_name: Table name containing OTEL traces
+        time_window_hours: Total time window to analyze
+        bucket_hours: Size of each time bucket for trending
+        service_name: Optional filter for specific service
+        metric: Which metric to track (p95, p99, error_rate, throughput)
+
+    Returns:
+        JSON with SQL query showing metric trends over time.
+    """
+    where_filter = ""
+    if service_name:
+        where_filter = f"AND JSON_EXTRACT_SCALAR(resource.attributes, '$.service.name') = '{service_name}'"
+
+    if metric == "p95":
+        metric_calc = "ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(95)], 2) as metric_value"
+        metric_name = "p95_latency_ms"
+    elif metric == "p99":
+        metric_calc = "ROUND(APPROX_QUANTILES(duration_nano / 1000000, 100)[OFFSET(99)], 2) as metric_value"
+        metric_name = "p99_latency_ms"
+    elif metric == "error_rate":
+        metric_calc = "ROUND(COUNTIF(status.code = 2) / COUNT(*) * 100, 2) as metric_value"
+        metric_name = "error_rate_pct"
+    elif metric == "throughput":
+        metric_calc = "COUNT(*) as metric_value"
+        metric_name = "request_count"
+    else:
+        return json.dumps(
+            {"error": f"Unknown metric: {metric}. Use p95, p99, error_rate, or throughput"}
+        )
+
+    query = f"""
+WITH time_buckets AS (
+  SELECT
+    TIMESTAMP_TRUNC(start_time, HOUR) as time_bucket,
+    {metric_calc},
+    COUNT(*) as sample_size
+  FROM `{dataset_id}.{table_name}`
+  WHERE start_time >= TIMESTAMP_SUB(CURRENT_TIMESTAMP(), INTERVAL {time_window_hours} HOUR)
+    AND parent_span_id IS NULL
+    {where_filter}
+  GROUP BY time_bucket
+  HAVING sample_size >= 10
+  ORDER BY time_bucket
+),
+with_moving_avg AS (
+  SELECT
+    time_bucket,
+    metric_value,
+    sample_size,
+    AVG(metric_value) OVER (
+      ORDER BY time_bucket
+      ROWS BETWEEN 2 PRECEDING AND CURRENT ROW
+    ) as moving_avg_3h,
+    metric_value - LAG(metric_value, 1) OVER (ORDER BY time_bucket) as delta_1h,
+    ROUND((metric_value - LAG(metric_value, 1) OVER (ORDER BY time_bucket)) /
+          LAG(metric_value, 1) OVER (ORDER BY time_bucket) * 100, 1) as pct_change_1h
+  FROM time_buckets
+)
+SELECT
+  time_bucket,
+  metric_value as {metric_name},
+  sample_size,
+  ROUND(moving_avg_3h, 2) as moving_avg_3h,
+  delta_1h,
+  pct_change_1h,
+  CASE
+    WHEN ABS(pct_change_1h) >= 20 THEN 'SIGNIFICANT_CHANGE'
+    WHEN ABS(pct_change_1h) >= 10 THEN 'MODERATE_CHANGE'
+    ELSE 'STABLE'
+  END as change_magnitude
+FROM with_moving_avg
+ORDER BY time_bucket DESC
+"""
+
+    logger.info(f"Generated Trend Detection SQL ({metric}):\n{query.strip()}")
+
+    return json.dumps(
+        {
+            "analysis_type": "trend_detection",
+            "sql_query": query.strip(),
+            "metric": metric,
+            "time_window_hours": time_window_hours,
+            "bucket_hours": bucket_hours,
+            "description": f"Detect trend changes in {metric} over {time_window_hours}h",
+            "next_steps": [
+                "Execute this query using BigQuery MCP execute_sql tool",
+                "Look for rows with change_magnitude = 'SIGNIFICANT_CHANGE'",
+                "Note the time_bucket when degradation started",
+                "Use compare_time_periods with before/after time ranges",
+            ],
+        }
+    )

--- a/sre_agent/tools/common/__init__.py
+++ b/sre_agent/tools/common/__init__.py
@@ -1,0 +1,14 @@
+"""Common utilities for SRE Agent tools."""
+
+from .decorators import adk_tool
+from .telemetry import get_tracer, get_meter, log_tool_call
+from .cache import DataCache, get_data_cache
+
+__all__ = [
+    "adk_tool",
+    "get_tracer",
+    "get_meter",
+    "log_tool_call",
+    "DataCache",
+    "get_data_cache",
+]

--- a/sre_agent/tools/common/cache.py
+++ b/sre_agent/tools/common/cache.py
@@ -1,0 +1,157 @@
+"""Thread-safe cache to prevent duplicate API calls."""
+
+import logging
+import threading
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class DataCache:
+    """
+    Thread-safe cache to prevent duplicate API calls.
+
+    This cache stores data with TTL (time-to-live) expiration.
+    It's designed to eliminate redundant API calls when multiple sub-agents
+    request the same data during parallel analysis.
+
+    The cache is particularly important in parallel architectures
+    where multiple agents may need the same data simultaneously.
+
+    Thread Safety:
+        All operations use a threading.Lock to ensure thread-safe access.
+
+    Memory Management:
+        Expired entries are automatically removed during get() operations.
+
+    Example:
+        >>> cache = DataCache(ttl_seconds=300)
+        >>> cache.put("trace123", '{"trace_id": "trace123", "spans": [...]}')
+        >>> data = cache.get("trace123")  # Returns cached data
+        >>> data = cache.get("trace999")  # Returns None (not found)
+    """
+
+    def __init__(self, ttl_seconds: int = 300):
+        """
+        Initialize the data cache.
+
+        Args:
+            ttl_seconds: Time-to-live for cached entries in seconds.
+                        Default is 300 seconds (5 minutes).
+        """
+        self._cache: dict[str, dict[str, Any]] = {}
+        self._lock = threading.Lock()
+        self.ttl_seconds = ttl_seconds
+        logger.info(f"DataCache initialized with TTL={ttl_seconds}s")
+
+    def get(self, key: str) -> Any | None:
+        """
+        Get cached data if available and not expired.
+
+        This method automatically removes expired entries during lookup.
+
+        Args:
+            key: The cache key to look up.
+
+        Returns:
+            The cached data, or None if not found or expired.
+        """
+        with self._lock:
+            entry = self._cache.get(key)
+            if entry:
+                if datetime.now(timezone.utc) < entry["expires"]:
+                    logger.debug(f"Cache HIT for key {key}")
+                    return entry["data"]
+                else:
+                    # Entry expired, remove it
+                    logger.debug(f"Cache EXPIRED for key {key}")
+                    del self._cache[key]
+                    return None
+            else:
+                logger.debug(f"Cache MISS for key {key}")
+                return None
+
+    def put(self, key: str, data: Any):
+        """
+        Cache data with expiration.
+
+        Args:
+            key: The cache key.
+            data: The data to cache.
+        """
+        with self._lock:
+            self._cache[key] = {
+                "data": data,
+                "expires": datetime.now(timezone.utc)
+                + timedelta(seconds=self.ttl_seconds),
+                "cached_at": datetime.now(timezone.utc),
+            }
+            logger.debug(f"Cached key {key} (TTL={self.ttl_seconds}s)")
+
+    def clear(self):
+        """Clear all cached entries."""
+        with self._lock:
+            count = len(self._cache)
+            self._cache.clear()
+            logger.info(f"Cache cleared ({count} entries removed)")
+
+    def size(self) -> int:
+        """
+        Get the number of cached entries.
+
+        Note: This includes both valid and expired entries.
+        Expired entries are only removed during get() operations.
+
+        Returns:
+            The number of cached entries.
+        """
+        with self._lock:
+            return len(self._cache)
+
+    def stats(self) -> dict[str, Any]:
+        """
+        Get cache statistics.
+
+        Returns:
+            Dictionary with cache statistics including:
+            - total_entries: Total number of cached entries
+            - expired_entries: Number of expired entries
+            - active_entries: Number of active (non-expired) entries
+        """
+        with self._lock:
+            now = datetime.now(timezone.utc)
+            total = len(self._cache)
+            expired = sum(
+                1 for entry in self._cache.values() if now >= entry["expires"]
+            )
+            active = total - expired
+
+            return {
+                "total_entries": total,
+                "expired_entries": expired,
+                "active_entries": active,
+                "ttl_seconds": self.ttl_seconds,
+            }
+
+
+# Global singleton instance
+_data_cache = DataCache()
+
+
+def get_data_cache() -> DataCache:
+    """
+    Get the global data cache instance.
+
+    This function provides access to the singleton DataCache instance
+    used throughout the application.
+
+    Returns:
+        The global DataCache instance.
+
+    Example:
+        >>> from sre_agent.tools.common.cache import get_data_cache
+        >>> cache = get_data_cache()
+        >>> cache.put("key123", data)
+    """
+    return _data_cache

--- a/sre_agent/tools/common/decorators.py
+++ b/sre_agent/tools/common/decorators.py
@@ -1,0 +1,155 @@
+"""Decorators for SRE Agent tools with OpenTelemetry instrumentation."""
+
+import functools
+import inspect
+import logging
+import time
+from collections.abc import Callable
+from typing import Any
+
+from opentelemetry import metrics, trace
+from opentelemetry.trace import Status, StatusCode
+
+logger = logging.getLogger(__name__)
+
+# Initialize OTel instruments
+tracer = trace.get_tracer("sre_agent.tools")
+meter = metrics.get_meter("sre_agent.tools")
+
+tool_execution_duration = meter.create_histogram(
+    name="sre_agent.tool.execution_duration",
+    description="Duration of tool executions",
+    unit="ms",
+)
+tool_execution_count = meter.create_counter(
+    name="sre_agent.tool.execution_count",
+    description="Total number of tool calls",
+    unit="1",
+)
+
+
+def adk_tool(func: Callable[..., Any]) -> Callable[..., Any]:  # noqa: C901
+    """
+    Decorator to mark a function as an ADK tool and provide automatic
+    logging and instrumentation.
+
+    This decorator provides:
+    - OTel Spans for every execution
+    - OTel Metrics (count and duration)
+    - Standardized Logging of args and results/errors
+    - Error handling (ensures errors are logged before raising/returning)
+
+    Example:
+        @adk_tool
+        async def fetch_trace(trace_id: str) -> dict:
+            ...
+    """
+
+    def _record_attributes(span, bound_args):
+        for k, v in bound_args.arguments.items():
+            # Truncate long strings to avoid span attribute limits
+            val_str = str(v)
+            if len(val_str) > 1000:
+                val_str = val_str[:1000] + "...(truncated)"
+            span.set_attribute(f"arg.{k}", val_str)
+
+    @functools.wraps(func)
+    async def async_wrapper(*args, **kwargs):
+        tool_name = func.__name__
+        start_time = time.time()
+        success = True
+
+        with tracer.start_as_current_span(tool_name) as span:
+            span.set_attribute("tool.name", tool_name)
+            span.set_attribute("code.function", tool_name)
+
+            # Log calling
+            try:
+                sig = inspect.signature(func)
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+                arg_str = ", ".join(
+                    f"{k}={repr(v)[:200]}" for k, v in bound.arguments.items()
+                )
+                _record_attributes(span, bound)
+            except Exception:
+                arg_str = f"args={args}, kwargs={kwargs}"
+
+            logger.info(f"Tool '{tool_name}' called with: {arg_str}")
+
+            try:
+                result = await func(*args, **kwargs)
+                duration_ms = (time.time() - start_time) * 1000
+                logger.info(f"Tool '{tool_name}' completed in {duration_ms:.2f}ms")
+                return result
+            except Exception as e:
+                success = False
+                duration_ms = (time.time() - start_time) * 1000
+                logger.error(
+                    f"Tool '{tool_name}' failed after {duration_ms:.2f}ms: {e}",
+                    exc_info=True,
+                )
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                raise e
+            finally:
+                duration_ms = (time.time() - start_time) * 1000
+                tool_execution_duration.record(
+                    duration_ms, {"tool.name": tool_name, "success": str(success)}
+                )
+                tool_execution_count.add(
+                    1, {"tool.name": tool_name, "success": str(success)}
+                )
+
+    @functools.wraps(func)
+    def sync_wrapper(*args, **kwargs):
+        tool_name = func.__name__
+        start_time = time.time()
+        success = True
+
+        with tracer.start_as_current_span(tool_name) as span:
+            span.set_attribute("tool.name", tool_name)
+            span.set_attribute("code.function", tool_name)
+
+            # Log calling
+            try:
+                sig = inspect.signature(func)
+                bound = sig.bind(*args, **kwargs)
+                bound.apply_defaults()
+                arg_str = ", ".join(
+                    f"{k}={repr(v)[:200]}" for k, v in bound.arguments.items()
+                )
+                _record_attributes(span, bound)
+            except Exception:
+                arg_str = f"args={args}, kwargs={kwargs}"
+
+            logger.info(f"Tool '{tool_name}' called with: {arg_str}")
+
+            try:
+                result = func(*args, **kwargs)
+                duration_ms = (time.time() - start_time) * 1000
+                logger.info(f"Tool '{tool_name}' completed in {duration_ms:.2f}ms")
+                return result
+            except Exception as e:
+                success = False
+                duration_ms = (time.time() - start_time) * 1000
+                logger.error(
+                    f"Tool '{tool_name}' failed after {duration_ms:.2f}ms: {e}",
+                    exc_info=True,
+                )
+                span.record_exception(e)
+                span.set_status(Status(StatusCode.ERROR, str(e)))
+                raise e
+            finally:
+                duration_ms = (time.time() - start_time) * 1000
+                tool_execution_duration.record(
+                    duration_ms, {"tool.name": tool_name, "success": str(success)}
+                )
+                tool_execution_count.add(
+                    1, {"tool.name": tool_name, "success": str(success)}
+                )
+
+    if inspect.iscoroutinefunction(func):
+        return async_wrapper
+    else:
+        return sync_wrapper

--- a/sre_agent/tools/common/telemetry.py
+++ b/sre_agent/tools/common/telemetry.py
@@ -1,0 +1,49 @@
+"""Telemetry setup for SRE Agent using OpenTelemetry."""
+
+import logging
+
+from opentelemetry import metrics, trace
+
+
+# Filter out the specific warning from google-generativeai types regarding function calls
+class _FunctionCallWarningFilter(logging.Filter):
+    def filter(self, record):
+        return (
+            "Warning: there are non-text parts in the response"
+            not in record.getMessage()
+        )
+
+
+# Apply filter to root logger and google.generativeai logger
+logging.getLogger().addFilter(_FunctionCallWarningFilter())
+logging.getLogger("google.generativeai").addFilter(_FunctionCallWarningFilter())
+
+
+def get_tracer(name: str):
+    """Returns a tracer for the given module name."""
+    return trace.get_tracer(name)
+
+
+def get_meter(name: str):
+    """Returns a meter for the given module name."""
+    return metrics.get_meter(name)
+
+
+def log_tool_call(logger: logging.Logger, func_name: str, **kwargs):
+    """
+    Logs a tool call with arguments, truncating long values.
+
+    Args:
+        logger: The logger instance to use.
+        func_name: Name of the function being called.
+        **kwargs: Arguments to log.
+    """
+    safe_args = {}
+    for k, v in kwargs.items():
+        val_str = str(v)
+        if len(val_str) > 200:
+            safe_args[k] = val_str[:200] + "... (truncated)"
+        else:
+            safe_args[k] = val_str
+
+    logger.debug(f"Tool Call: {func_name} | Args: {safe_args}")

--- a/sre_agent/tools/gcp/__init__.py
+++ b/sre_agent/tools/gcp/__init__.py
@@ -1,0 +1,56 @@
+"""Google Cloud Platform tools for SRE Agent.
+
+This module provides tools for interacting with GCP Observability services:
+- BigQuery MCP for SQL-based analysis
+- Cloud Logging MCP for log queries
+- Cloud Monitoring MCP for metrics queries
+- Direct API clients as fallback
+
+MCP Tools (via Model Context Protocol):
+- BigQuery: execute_sql, list_dataset_ids, list_table_ids, get_table_info
+- Logging: list_log_entries
+- Monitoring: list_timeseries, query_range
+
+Direct API Tools:
+- Logging: list_log_entries, get_logs_for_trace
+- Monitoring: list_time_series
+- Error Reporting: list_error_events
+"""
+
+from .mcp import (
+    create_bigquery_mcp_toolset,
+    create_logging_mcp_toolset,
+    create_monitoring_mcp_toolset,
+    call_mcp_tool_with_retry,
+    mcp_list_log_entries,
+    mcp_list_timeseries,
+    mcp_query_range,
+    get_project_id_with_fallback,
+)
+from .clients import (
+    list_log_entries,
+    list_time_series,
+    list_error_events,
+    get_logs_for_trace,
+    get_current_time,
+)
+
+__all__ = [
+    # MCP toolset factories
+    "create_bigquery_mcp_toolset",
+    "create_logging_mcp_toolset",
+    "create_monitoring_mcp_toolset",
+    "call_mcp_tool_with_retry",
+    # MCP tools
+    "mcp_list_log_entries",
+    "mcp_list_timeseries",
+    "mcp_query_range",
+    # Direct API tools
+    "list_log_entries",
+    "list_time_series",
+    "list_error_events",
+    "get_logs_for_trace",
+    "get_current_time",
+    # Utilities
+    "get_project_id_with_fallback",
+]

--- a/sre_agent/tools/gcp/clients.py
+++ b/sre_agent/tools/gcp/clients.py
@@ -1,0 +1,202 @@
+"""Direct API clients for GCP observability services.
+
+These tools use direct GCP client libraries. They are useful as fallbacks
+when MCP is unavailable or for simple queries that don't need MCP features.
+"""
+
+import json
+import logging
+import time
+from datetime import datetime, timezone
+
+from google.cloud import monitoring_v3
+from google.cloud.logging_v2.services.logging_service_v2 import LoggingServiceV2Client
+
+from ..common import adk_tool
+
+logger = logging.getLogger(__name__)
+
+
+@adk_tool
+def list_log_entries(project_id: str, filter_str: str, limit: int = 10) -> str:
+    """
+    Lists log entries from Google Cloud Logging using direct API.
+
+    Args:
+        project_id: The Google Cloud Project ID.
+        filter_str: The filter string to use.
+        limit: The maximum number of log entries to return.
+
+    Returns:
+        A JSON string representing the list of log entries.
+
+    Example filter_str: 'resource.type="gce_instance" AND severity="ERROR"'
+    """
+    try:
+        client = LoggingServiceV2Client()
+        resource_names = [f"projects/{project_id}"]
+        entries = client.list_log_entries(
+            request={
+                "resource_names": resource_names,
+                "filter": filter_str,
+                "page_size": limit,
+            }
+        )
+        results = []
+        for entry in entries:
+            payload_str = str(entry.payload)
+            if len(payload_str) > 500:
+                payload_str = payload_str[:500] + "...(truncated)"
+
+            results.append(
+                {
+                    "timestamp": entry.timestamp.isoformat(),
+                    "severity": entry.severity.name,
+                    "payload": payload_str,
+                    "resource": {
+                        "type": entry.resource.type,
+                        "labels": dict(entry.resource.labels),
+                    },
+                }
+            )
+        return json.dumps(results)
+    except Exception as e:
+        error_msg = f"Failed to list log entries: {e!s}"
+        logger.error(error_msg)
+        return json.dumps({"error": error_msg})
+
+
+@adk_tool
+def list_time_series(project_id: str, filter_str: str, minutes_ago: int = 60) -> str:
+    """
+    Lists time series data from Google Cloud Monitoring using direct API.
+
+    Args:
+        project_id: The Google Cloud Project ID.
+        filter_str: The filter string to use.
+        minutes_ago: The number of minutes in the past to query.
+
+    Returns:
+        A JSON string representing the list of time series.
+
+    Example filter_str: 'metric.type="compute.googleapis.com/instance/cpu/utilization"'
+    """
+    try:
+        client = monitoring_v3.MetricServiceClient()
+        project_name = f"projects/{project_id}"
+        now = time.time()
+        seconds = int(now)
+        nanos = int((now - seconds) * 10**9)
+        interval = monitoring_v3.TimeInterval(
+            {
+                "end_time": {"seconds": seconds, "nanos": nanos},
+                "start_time": {
+                    "seconds": seconds - (minutes_ago * 60),
+                    "nanos": nanos,
+                },
+            }
+        )
+        results = client.list_time_series(
+            name=project_name,
+            filter=filter_str,
+            interval=interval,
+            view=monitoring_v3.ListTimeSeriesRequest.TimeSeriesView.FULL,
+        )
+        time_series_data = []
+        for result in results:
+            time_series_data.append(
+                {
+                    "metric": {
+                        "type": result.metric.type,
+                        "labels": dict(result.metric.labels),
+                    },
+                    "resource": {
+                        "type": result.resource.type,
+                        "labels": dict(result.resource.labels),
+                    },
+                    "points": [
+                        {
+                            "timestamp": point.interval.end_time.isoformat(),
+                            "value": point.value.double_value,
+                        }
+                        for point in result.points
+                    ],
+                }
+            )
+        return json.dumps(time_series_data)
+    except Exception as e:
+        error_msg = f"Failed to list time series: {e!s}"
+        logger.error(error_msg)
+        return json.dumps({"error": error_msg})
+
+
+@adk_tool
+def list_error_events(project_id: str, minutes_ago: int = 60) -> str:
+    """
+    Lists error events from Google Cloud Error Reporting using direct API.
+
+    Args:
+        project_id: The Google Cloud Project ID.
+        minutes_ago: The number of minutes in the past to query.
+
+    Returns:
+        A JSON string representing the list of error events.
+    """
+    try:
+        import google.cloud.errorreporting_v1beta1 as errorreporting_v1beta1
+
+        client = errorreporting_v1beta1.ErrorStatsServiceClient()
+        project_name = f"projects/{project_id}"
+        time_range = errorreporting_v1beta1.QueryTimeRange()
+        time_range.period = errorreporting_v1beta1.QueryTimeRange.Period.PERIOD_1_HOUR
+        request = errorreporting_v1beta1.ListEventsRequest(
+            project_name=project_name,
+            group_id=None,
+            time_range=time_range,
+            page_size=100,
+        )
+
+        events = client.list_events(request=request)
+
+        results = []
+        for event in events:
+            results.append(
+                {
+                    "event_time": event.event_time.isoformat(),
+                    "message": event.message,
+                    "service_context": {
+                        "service": event.service_context.service,
+                        "version": event.service_context.version,
+                    },
+                }
+            )
+        return json.dumps(results)
+    except Exception as e:
+        error_msg = f"Failed to list error events: {e!s}"
+        logger.error(error_msg)
+        return json.dumps({"error": error_msg})
+
+
+@adk_tool
+def get_logs_for_trace(project_id: str, trace_id: str, limit: int = 100) -> str:
+    """
+    Fetches log entries correlated with a specific trace ID.
+
+    Args:
+        project_id: The Google Cloud Project ID.
+        trace_id: The unique trace ID.
+        limit: Max logs to return.
+
+    Returns:
+        JSON list of log entries.
+    """
+    filter_str = f'trace="projects/{project_id}/traces/{trace_id}"'
+    return list_log_entries(project_id, filter_str, limit)
+
+
+def get_current_time() -> str:
+    """
+    Returns the current UTC time in ISO format.
+    Use this to calculate relative time ranges (e.g., 'now - 1 hour') for queries.
+    """
+    return datetime.now(timezone.utc).isoformat()

--- a/sre_agent/tools/gcp/mcp.py
+++ b/sre_agent/tools/gcp/mcp.py
@@ -1,0 +1,463 @@
+"""MCP (Model Context Protocol) integration for GCP services.
+
+This module provides lazy-loaded MCP toolsets for GCP observability services:
+- BigQuery: SQL-based data analysis
+- Cloud Logging: Log queries and analysis
+- Cloud Monitoring: Metrics and time series queries
+
+MCP toolsets are created lazily in async context to avoid session lifecycle issues.
+Creating at module import time causes "Attempted to exit cancel scope in a
+different task" errors because anyio cancel scopes cannot cross task boundaries.
+"""
+
+import asyncio
+import logging
+import os
+from datetime import datetime, timezone
+
+import google.auth
+from google.adk.tools import ToolContext
+from google.adk.tools.api_registry import ApiRegistry
+
+from ..common import adk_tool
+
+logger = logging.getLogger(__name__)
+
+
+def get_project_id_with_fallback() -> str | None:
+    """Get project ID from environment or default credentials."""
+    project_id = None
+    try:
+        _, project_id = google.auth.default()
+        project_id = project_id or os.environ.get("GOOGLE_CLOUD_PROJECT")
+    except Exception:
+        pass
+    return project_id
+
+
+def create_bigquery_mcp_toolset(project_id: str | None = None):
+    """
+    Creates a new instance of the BigQuery MCP toolset.
+
+    NOTE: This function should be called in an async context (within an async
+    function) to ensure proper MCP session lifecycle management.
+
+    Tools exposed:
+        - execute_sql: Execute SQL queries
+        - list_dataset_ids: List available datasets
+        - list_table_ids: List tables in a dataset
+        - get_table_info: Get table schema and metadata
+
+    Environment variable override:
+        BIGQUERY_MCP_SERVER: Override the default MCP server
+
+    Args:
+        project_id: GCP project ID. If not provided, uses default credentials.
+
+    Returns:
+        MCP toolset or None if unavailable.
+    """
+    if not project_id:
+        project_id = get_project_id_with_fallback()
+
+    if not project_id:
+        logger.warning("No Project ID detected; BigQuery MCP toolset will not be available")
+        return None
+
+    try:
+        logger.info(f"Creating BigQuery MCP toolset for project: {project_id}")
+
+        default_server = "google-bigquery.googleapis.com-mcp"
+        mcp_server = os.environ.get("BIGQUERY_MCP_SERVER", default_server)
+        mcp_server_name = f"projects/{project_id}/locations/global/mcpServers/{mcp_server}"
+
+        api_registry = ApiRegistry(
+            project_id, header_provider=lambda _: {"x-goog-user-project": project_id}
+        )
+
+        mcp_toolset = api_registry.get_toolset(
+            mcp_server_name=mcp_server_name,
+            tool_filter=[
+                "execute_sql",
+                "list_dataset_ids",
+                "list_table_ids",
+                "get_table_info",
+            ],
+        )
+
+        return mcp_toolset
+
+    except Exception as e:
+        logger.error(f"Failed to create BigQuery MCP toolset: {e}", exc_info=True)
+        return None
+
+
+def create_logging_mcp_toolset(project_id: str | None = None):
+    """
+    Creates a Cloud Logging MCP toolset with generic logging capabilities.
+
+    Tools exposed:
+        - list_log_entries: Search and retrieve log entries
+
+    Environment variable override:
+        LOGGING_MCP_SERVER: Override the default MCP server
+
+    Args:
+        project_id: GCP project ID. If not provided, uses default credentials.
+
+    Returns:
+        MCP toolset or None if unavailable.
+    """
+    if not project_id:
+        project_id = get_project_id_with_fallback()
+
+    if not project_id:
+        logger.warning("No Project ID detected; Cloud Logging MCP toolset will not be available")
+        return None
+
+    try:
+        logger.info(f"Creating Cloud Logging MCP toolset for project: {project_id}")
+
+        default_server = "logging.googleapis.com-mcp"
+        mcp_server = os.environ.get("LOGGING_MCP_SERVER", default_server)
+        mcp_server_name = f"projects/{project_id}/locations/global/mcpServers/{mcp_server}"
+
+        api_registry = ApiRegistry(
+            project_id, header_provider=lambda _: {"x-goog-user-project": project_id}
+        )
+
+        mcp_toolset = api_registry.get_toolset(
+            mcp_server_name=mcp_server_name,
+            tool_filter=["list_log_entries"],
+        )
+
+        return mcp_toolset
+
+    except Exception as e:
+        logger.error(f"Failed to create Cloud Logging MCP toolset: {e}", exc_info=True)
+        return None
+
+
+def create_monitoring_mcp_toolset(project_id: str | None = None):
+    """
+    Creates a Cloud Monitoring MCP toolset with generic metrics capabilities.
+
+    Tools exposed:
+        - list_timeseries: Query time series metrics data
+        - query_range: Evaluate PromQL queries over a time range
+
+    Environment variable override:
+        MONITORING_MCP_SERVER: Override the default MCP server
+
+    Args:
+        project_id: GCP project ID. If not provided, uses default credentials.
+
+    Returns:
+        MCP toolset or None if unavailable.
+    """
+    if not project_id:
+        project_id = get_project_id_with_fallback()
+
+    if not project_id:
+        logger.warning("No Project ID detected; Cloud Monitoring MCP toolset will not be available")
+        return None
+
+    try:
+        logger.info(f"Creating Cloud Monitoring MCP toolset for project: {project_id}")
+
+        default_server = "monitoring.googleapis.com-mcp"
+        mcp_server = os.environ.get("MONITORING_MCP_SERVER", default_server)
+        mcp_server_name = f"projects/{project_id}/locations/global/mcpServers/{mcp_server}"
+
+        api_registry = ApiRegistry(
+            project_id, header_provider=lambda _: {"x-goog-user-project": project_id}
+        )
+
+        mcp_toolset = api_registry.get_toolset(
+            mcp_server_name=mcp_server_name,
+            tool_filter=["list_timeseries", "query_range"],
+        )
+
+        return mcp_toolset
+
+    except Exception as e:
+        logger.error(f"Failed to create Cloud Monitoring MCP toolset: {e}", exc_info=True)
+        return None
+
+
+async def call_mcp_tool_with_retry(
+    create_toolset_fn,
+    tool_name: str,
+    args: dict,
+    tool_context: ToolContext,
+    project_id: str | None = None,
+    max_retries: int = 3,
+    base_delay: float = 1.0,
+) -> dict:
+    """
+    Generic helper to call an MCP tool with retry logic for session errors.
+
+    Args:
+        create_toolset_fn: Function to create the MCP toolset.
+        tool_name: Name of the MCP tool to call.
+        args: Arguments to pass to the tool.
+        tool_context: ADK tool context.
+        project_id: Optional project ID override.
+        max_retries: Max retry attempts for session errors.
+        base_delay: Base delay for exponential backoff.
+
+    Returns:
+        Tool result or error dict.
+    """
+    if not project_id:
+        project_id = get_project_id_with_fallback()
+
+    if not project_id:
+        return {"error": "No project ID available. Set GOOGLE_CLOUD_PROJECT environment variable."}
+
+    for attempt in range(max_retries):
+        try:
+            mcp_toolset = create_toolset_fn(project_id)
+
+            if not mcp_toolset:
+                return {"error": f"MCP toolset unavailable for {tool_name}"}
+
+            tools = await mcp_toolset.get_tools()
+
+            for tool in tools:
+                if tool.name == tool_name:
+                    result = await tool.run_async(args=args, tool_context=tool_context)
+                    return {"source": "mcp", "result": result}
+
+            return {"error": f"{tool_name} tool not found in MCP toolset"}
+
+        except Exception as e:
+            error_str = str(e)
+            is_session_error = (
+                "Session terminated" in error_str
+                or "session" in error_str.lower() and "error" in error_str.lower()
+            )
+
+            if is_session_error and attempt < max_retries - 1:
+                delay = base_delay * (2 ** attempt)
+                logger.warning(
+                    f"MCP session error during {tool_name} attempt {attempt + 1}/{max_retries}: {e}. "
+                    f"Retrying in {delay}s..."
+                )
+                await asyncio.sleep(delay)
+            else:
+                if attempt >= max_retries - 1:
+                    logger.error(f"{tool_name} failed after {max_retries} attempts: {e}")
+                raise
+
+
+# =============================================================================
+# Generic GCP MCP Tools
+# =============================================================================
+
+
+@adk_tool
+async def mcp_list_log_entries(
+    filter: str,
+    project_id: str | None = None,
+    page_size: int = 100,
+    order_by: str | None = None,
+    tool_context: ToolContext = None,
+) -> dict:
+    """
+    Search and retrieve log entries from Google Cloud Logging via MCP.
+
+    This is the primary tool for querying Cloud Logging. Use it for debugging
+    application behavior, finding specific error messages, auditing events,
+    or any log analysis task.
+
+    Args:
+        filter: Cloud Logging filter expression. Powerful syntax for selecting logs
+            by severity, resource type, text content, labels, and more.
+        project_id: GCP project ID. If not provided, uses default credentials.
+        page_size: Maximum number of log entries to return (default 100).
+        order_by: Optional field to sort by (e.g., "timestamp desc").
+        tool_context: ADK tool context (required).
+
+    Returns:
+        Log entries matching the filter criteria.
+
+    Example filters:
+        - 'severity>=ERROR' - All errors and above
+        - 'resource.type="k8s_container"' - Kubernetes container logs
+        - 'resource.type="gce_instance"' - Compute Engine logs
+        - 'textPayload:"OutOfMemory"' - Logs containing specific text
+        - 'jsonPayload.level="error"' - Structured logs by field
+        - 'trace="projects/PROJECT/traces/TRACE_ID"' - Logs for a trace
+        - 'timestamp>="2024-01-01T00:00:00Z"' - Time-bounded queries
+        - 'labels.env="production" AND severity>=WARNING' - Combined filters
+    """
+    if tool_context is None:
+        raise ValueError("tool_context is required for MCP tools")
+
+    args = {
+        "filter": filter,
+        "page_size": page_size,
+    }
+    if order_by:
+        args["order_by"] = order_by
+
+    # Add resource_names if project_id is available
+    pid = project_id or get_project_id_with_fallback()
+    if pid:
+        args["resource_names"] = [f"projects/{pid}"]
+
+    return await call_mcp_tool_with_retry(
+        create_logging_mcp_toolset,
+        "list_log_entries",
+        args,
+        tool_context,
+        project_id=project_id,
+    )
+
+
+@adk_tool
+async def mcp_list_timeseries(
+    filter: str,
+    project_id: str | None = None,
+    interval_start_time: str | None = None,
+    interval_end_time: str | None = None,
+    minutes_ago: int = 60,
+    aggregation: dict | None = None,
+    tool_context: ToolContext = None,
+) -> dict:
+    """
+    Query time series metrics data from Google Cloud Monitoring via MCP.
+
+    Use this tool to retrieve metric values over time for monitoring, alerting,
+    capacity planning, performance analysis, or any metrics-based task.
+
+    Args:
+        filter: Monitoring filter string for selecting metrics and resources.
+        project_id: GCP project ID. If not provided, uses default credentials.
+        interval_start_time: Start of time interval (ISO format). If not provided,
+            calculated from minutes_ago.
+        interval_end_time: End of time interval (ISO format). If not provided,
+            uses current time.
+        minutes_ago: Minutes back from now for start time (default 60). Only used
+            if interval_start_time is not provided.
+        aggregation: Optional aggregation settings (alignment_period, per_series_aligner, etc.)
+        tool_context: ADK tool context (required).
+
+    Returns:
+        Time series data with metric values, labels, and timestamps.
+
+    Example filters:
+        - 'metric.type="compute.googleapis.com/instance/cpu/utilization"' - CPU usage
+        - 'metric.type="loadbalancing.googleapis.com/https/request_count"' - LB requests
+        - 'metric.type="cloudsql.googleapis.com/database/cpu/utilization"' - Cloud SQL CPU
+        - 'resource.labels.instance_id="12345"' - Filter by instance
+        - 'metric.labels.response_code="500"' - Filter by metric label
+    """
+    if tool_context is None:
+        raise ValueError("tool_context is required for MCP tools")
+
+    import time as time_module
+
+    pid = project_id or get_project_id_with_fallback()
+
+    # Build time interval
+    if interval_end_time:
+        end_dt = datetime.fromisoformat(interval_end_time.replace("Z", "+00:00"))
+        end_seconds = int(end_dt.timestamp())
+    else:
+        end_seconds = int(time_module.time())
+
+    if interval_start_time:
+        start_dt = datetime.fromisoformat(interval_start_time.replace("Z", "+00:00"))
+        start_seconds = int(start_dt.timestamp())
+    else:
+        start_seconds = end_seconds - (minutes_ago * 60)
+
+    args = {
+        "name": f"projects/{pid}" if pid else "",
+        "filter": filter,
+        "interval": {
+            "end_time": {"seconds": end_seconds},
+            "start_time": {"seconds": start_seconds},
+        },
+    }
+
+    if aggregation:
+        args["aggregation"] = aggregation
+
+    return await call_mcp_tool_with_retry(
+        create_monitoring_mcp_toolset,
+        "list_timeseries",
+        args,
+        tool_context,
+        project_id=project_id,
+    )
+
+
+@adk_tool
+async def mcp_query_range(
+    query: str,
+    project_id: str | None = None,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    minutes_ago: int = 60,
+    step: str = "60s",
+    tool_context: ToolContext = None,
+) -> dict:
+    """
+    Evaluate a PromQL query over a time range via Cloud Monitoring MCP.
+
+    Use this for complex metric aggregations, calculations, and analysis using
+    PromQL syntax. Ideal for rate calculations, histogram analysis, and
+    multi-metric correlations.
+
+    Args:
+        query: PromQL query expression.
+        project_id: GCP project ID. If not provided, uses default credentials.
+        start_time: Start of query range (ISO format or RFC3339).
+        end_time: End of query range (ISO format or RFC3339).
+        minutes_ago: Minutes back from now for start time (default 60).
+        step: Query resolution step (default "60s").
+        tool_context: ADK tool context (required).
+
+    Returns:
+        Query results with time series data.
+
+    Example queries:
+        - 'rate(http_requests_total[5m])' - Request rate over 5 minutes
+        - 'sum by (status_code)(http_requests_total)' - Requests grouped by status
+        - 'histogram_quantile(0.95, http_request_duration_bucket)' - P95 latency
+        - 'increase(errors_total[1h])' - Error count increase over 1 hour
+    """
+    if tool_context is None:
+        raise ValueError("tool_context is required for MCP tools")
+
+    import time as time_module
+
+    # Build time range
+    if end_time:
+        end_str = end_time
+    else:
+        end_str = datetime.now(timezone.utc).isoformat()
+
+    if start_time:
+        start_str = start_time
+    else:
+        start_ts = time_module.time() - (minutes_ago * 60)
+        start_str = datetime.fromtimestamp(start_ts, tz=timezone.utc).isoformat()
+
+    args = {
+        "query": query,
+        "start": start_str,
+        "end": end_str,
+        "step": step,
+    }
+
+    return await call_mcp_tool_with_retry(
+        create_monitoring_mcp_toolset,
+        "query_range",
+        args,
+        tool_context,
+        project_id=project_id,
+    )

--- a/sre_agent/tools/trace/__init__.py
+++ b/sre_agent/tools/trace/__init__.py
@@ -1,0 +1,89 @@
+"""Trace analysis tools for SRE Agent.
+
+This module provides tools for distributed trace analysis:
+- Cloud Trace API clients for fetching and listing traces
+- Trace analysis utilities (durations, errors, call graphs)
+- Trace comparison tools for diff analysis
+- Trace filter utilities for building query strings
+
+Tools:
+    Trace API:
+        - fetch_trace: Fetch a specific trace by ID
+        - list_traces: List traces with filtering
+        - find_example_traces: Discover representative traces
+        - get_trace_by_url: Parse Cloud Console URLs
+
+    Analysis:
+        - calculate_span_durations: Extract timing information
+        - extract_errors: Find error spans
+        - build_call_graph: Build hierarchical call graph
+        - summarize_trace: Create trace summary
+        - validate_trace_quality: Check trace data quality
+
+    Comparison:
+        - compare_span_timings: Compare timings between traces
+        - find_structural_differences: Compare call graph structures
+
+    Filters:
+        - TraceQueryBuilder: Build Cloud Trace filter strings
+        - build_trace_filter: Convenience filter builder
+        - select_traces_from_*: Trace selection strategies
+"""
+
+from .clients import (
+    fetch_trace,
+    fetch_trace_data,
+    list_traces,
+    find_example_traces,
+    get_trace_by_url,
+    get_current_time,
+    validate_trace,
+)
+from .analysis import (
+    calculate_span_durations,
+    extract_errors,
+    build_call_graph,
+    summarize_trace,
+    validate_trace_quality,
+)
+from .comparison import (
+    compare_span_timings,
+    find_structural_differences,
+)
+from .filters import (
+    TraceQueryBuilder,
+    TraceSelector,
+    build_trace_filter,
+    select_traces_from_error_reports,
+    select_traces_from_monitoring_alerts,
+    select_traces_from_statistical_outliers,
+    select_traces_manually,
+)
+
+__all__ = [
+    # API clients
+    "fetch_trace",
+    "fetch_trace_data",
+    "list_traces",
+    "find_example_traces",
+    "get_trace_by_url",
+    "get_current_time",
+    "validate_trace",
+    # Analysis
+    "calculate_span_durations",
+    "extract_errors",
+    "build_call_graph",
+    "summarize_trace",
+    "validate_trace_quality",
+    # Comparison
+    "compare_span_timings",
+    "find_structural_differences",
+    # Filters
+    "TraceQueryBuilder",
+    "TraceSelector",
+    "build_trace_filter",
+    "select_traces_from_error_reports",
+    "select_traces_from_monitoring_alerts",
+    "select_traces_from_statistical_outliers",
+    "select_traces_manually",
+]

--- a/sre_agent/tools/trace/analysis.py
+++ b/sre_agent/tools/trace/analysis.py
@@ -1,0 +1,503 @@
+"""Trace analysis utilities for span-level analysis."""
+
+import logging
+import time
+from datetime import datetime
+from typing import Any
+
+from ..common import adk_tool
+from ..common.telemetry import get_meter, get_tracer, log_tool_call
+from .clients import fetch_trace_data
+
+logger = logging.getLogger(__name__)
+
+# Telemetry setup
+tracer = get_tracer(__name__)
+meter = get_meter(__name__)
+
+# Metrics
+execution_duration = meter.create_histogram(
+    name="sre_agent.tool.execution_duration",
+    description="Duration of tool executions",
+    unit="ms",
+)
+execution_count = meter.create_counter(
+    name="sre_agent.tool.execution_count",
+    description="Total number of tool calls",
+    unit="1",
+)
+anomalies_detected = meter.create_counter(
+    name="sre_agent.analysis.anomalies_detected",
+    description="Count of anomalies found",
+    unit="1",
+)
+
+
+def _record_telemetry(func_name: str, success: bool = True, duration_ms: float = 0.0):
+    attributes = {
+        "code.function": func_name,
+        "code.namespace": __name__,
+        "success": str(success).lower(),
+        "sre_agent.tool.name": func_name,
+    }
+    execution_count.add(1, attributes)
+    execution_duration.record(duration_ms, attributes)
+
+
+# Type aliases
+TraceData = dict[str, Any]
+SpanData = dict[str, Any]
+
+
+@adk_tool
+def calculate_span_durations(
+    trace_id: str, project_id: str | None = None
+) -> list[SpanData]:
+    """
+    Extracts timing information for each span in a trace.
+
+    Args:
+        trace_id: The unique trace ID.
+        project_id: The Google Cloud Project ID.
+
+    Returns:
+        A list of span timing dictionaries with:
+        - span_id: Span identifier
+        - name: Span name/operation
+        - duration_ms: Duration in milliseconds
+        - start_time: ISO format start time
+        - end_time: ISO format end time
+        - parent_span_id: Parent span ID if any
+    """
+    start_time = time.time()
+    success = True
+
+    with tracer.start_as_current_span("calculate_span_durations") as span:
+        span.set_attribute("code.function", "calculate_span_durations")
+
+        log_tool_call(logger, "calculate_span_durations", trace_id=trace_id)
+
+        try:
+            trace = fetch_trace_data(trace_id, project_id)
+            if "error" in trace:
+                span.set_attribute("error", True)
+                span.set_status(trace.get("error"))
+                return [{"error": trace["error"]}]
+
+            spans = trace.get("spans", [])
+            span.set_attribute("sre_agent.span_count", len(spans))
+
+            timing_info = []
+
+            for s in spans:
+                s_start = s.get("start_time")
+                s_end = s.get("end_time")
+
+                duration_ms = None
+                if s_start and s_end:
+                    try:
+                        start_dt = datetime.fromisoformat(
+                            s_start.replace("Z", "+00:00")
+                        )
+                        end_dt = datetime.fromisoformat(s_end.replace("Z", "+00:00"))
+                        duration_ms = (end_dt - start_dt).total_seconds() * 1000
+                    except (ValueError, TypeError) as e:
+                        logger.warning(
+                            f"Failed to parse timestamps for span {s.get('span_id')}: {e}"
+                        )
+
+                timing_info.append(
+                    {
+                        "span_id": s.get("span_id"),
+                        "name": s.get("name"),
+                        "duration_ms": duration_ms,
+                        "start_time": s_start,
+                        "end_time": s_end,
+                        "parent_span_id": s.get("parent_span_id"),
+                        "labels": s.get("labels", {}),
+                    }
+                )
+
+            # Sort by duration (descending) for easy analysis
+            timing_info.sort(key=lambda x: x.get("duration_ms") or 0, reverse=True)
+
+            return timing_info
+
+        except Exception as e:
+            span.record_exception(e)
+            success = False
+            raise e
+        finally:
+            duration_ms = (time.time() - start_time) * 1000
+            _record_telemetry("calculate_span_durations", success, duration_ms)
+
+
+@adk_tool
+def extract_errors(  # noqa: C901
+    trace_id: str, project_id: str | None = None
+) -> list[dict[str, Any]]:
+    """
+    Finds all spans that contain errors or error-related information.
+
+    Args:
+        trace_id: The unique trace ID.
+        project_id: The Google Cloud Project ID.
+
+    Returns:
+        A list of error dictionaries with:
+        - span_id: Span identifier
+        - span_name: Name of the span with error
+        - error_type: Type/category of error
+        - error_message: Error message if available
+        - status_code: HTTP status code if applicable
+        - labels: All labels on the span
+    """
+    start_time = time.time()
+    success = True
+
+    with tracer.start_as_current_span("extract_errors") as span:
+        span.set_attribute("code.function", "extract_errors")
+
+        log_tool_call(logger, "extract_errors", trace_id=trace_id)
+
+        try:
+            trace = fetch_trace_data(trace_id, project_id)
+            if "error" in trace:
+                return [{"error": trace["error"]}]
+
+            spans = trace.get("spans", [])
+            errors = []
+
+            error_indicators = ["error", "exception", "fault", "failure"]
+
+            for s in spans:
+                labels = s.get("labels", {})
+                span_name = s.get("name", "")
+
+                is_error = False
+                error_info: dict[str, Any] = {
+                    "span_id": s.get("span_id"),
+                    "span_name": span_name,
+                    "error_type": None,
+                    "error_message": None,
+                    "status_code": None,
+                    "labels": labels,
+                }
+
+                for key, value in labels.items():
+                    key_lower = key.lower()
+                    value_str = str(value).lower() if value else ""
+
+                    # Check HTTP/gRPC status codes first
+                    if (
+                        "/http/status_code" in key_lower
+                        or "http.status_code" in key_lower
+                    ):
+                        try:
+                            code = int(value)
+                            if code >= 400:
+                                is_error = True
+                                error_info["status_code"] = code
+                                error_info["error_type"] = "http_error"
+                        except (ValueError, TypeError):
+                            pass
+                        continue
+
+                    # Check for general status/code fields
+                    if "status" in key_lower or "code" in key_lower:
+                        try:
+                            code = int(value)
+                            if code >= 400:
+                                is_error = True
+                                error_info["status_code"] = code
+                                error_info["error_type"] = "http_error"
+                        except (ValueError, TypeError):
+                            pass
+                        continue
+
+                    # Check for error/exception labels
+                    if any(indicator in key_lower for indicator in error_indicators):
+                        if value_str and value_str not in ("false", "0", "none", "ok"):
+                            is_error = True
+                            error_info["error_type"] = key
+                            error_info["error_message"] = str(value)
+
+                    # Check for gRPC error codes
+                    if "grpc" in key_lower and "status" in key_lower:
+                        if value_str not in ("ok", "0"):
+                            is_error = True
+                            error_info["error_type"] = "gRPC Error"
+                            error_info["status_code"] = value
+
+                if is_error:
+                    errors.append(error_info)
+
+            span.set_attribute("sre_agent.error_count", len(errors))
+            anomalies_detected.add(len(errors), {"type": "error_span"})
+
+            return errors
+        except Exception as e:
+            span.record_exception(e)
+            success = False
+            raise e
+        finally:
+            duration_ms = (time.time() - start_time) * 1000
+            _record_telemetry("extract_errors", success, duration_ms)
+
+
+@adk_tool
+def validate_trace_quality(  # noqa: C901
+    trace_id: str, project_id: str | None = None
+) -> dict[str, Any]:
+    """
+    Validate trace data quality and detect issues.
+
+    Checks for:
+    - Orphaned spans (missing parent)
+    - Negative durations
+    - Clock skew (child span outside parent timespan)
+    - Timestamp parsing errors
+
+    Args:
+        trace_id: The unique trace ID.
+        project_id: The Google Cloud Project ID.
+
+    Returns:
+        Dictionary with 'valid' boolean, 'issue_count', and list of 'issues'.
+    """
+    trace = fetch_trace_data(trace_id, project_id)
+    if "error" in trace:
+        return {
+            "valid": False,
+            "issue_count": 1,
+            "issues": [{"type": "fetch_error", "message": trace["error"]}],
+        }
+
+    spans = trace.get("spans", [])
+    issues = []
+
+    # Build parent-child map
+    span_map = {s["span_id"]: s for s in spans if "span_id" in s}
+
+    for span in spans:
+        span_id = span.get("span_id")
+        if not span_id:
+            issues.append({"type": "missing_span_id", "message": "Span missing ID"})
+            continue
+
+        # Check for orphaned spans
+        parent_id = span.get("parent_span_id")
+        if parent_id and parent_id not in span_map:
+            issues.append(
+                {
+                    "type": "orphaned_span",
+                    "span_id": span_id,
+                    "message": f"Parent span {parent_id} not found",
+                }
+            )
+
+        # Check for negative durations and clock skew
+        try:
+            start_str = span.get("start_time")
+            end_str = span.get("end_time")
+
+            if start_str and end_str:
+                start = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+                end = datetime.fromisoformat(end_str.replace("Z", "+00:00"))
+                duration = (end - start).total_seconds()
+
+                if duration < 0:
+                    issues.append(
+                        {
+                            "type": "negative_duration",
+                            "span_id": span_id,
+                            "duration_s": duration,
+                        }
+                    )
+
+                # Check clock skew
+                if parent_id and parent_id in span_map:
+                    parent = span_map[parent_id]
+                    p_start_str = parent.get("start_time")
+                    p_end_str = parent.get("end_time")
+
+                    if p_start_str and p_end_str:
+                        p_start = datetime.fromisoformat(
+                            p_start_str.replace("Z", "+00:00")
+                        )
+                        p_end = datetime.fromisoformat(p_end_str.replace("Z", "+00:00"))
+
+                        if start < p_start or end > p_end:
+                            issues.append(
+                                {
+                                    "type": "clock_skew",
+                                    "span_id": span_id,
+                                    "message": "Child span outside parent timespan",
+                                }
+                            )
+        except (ValueError, TypeError, KeyError) as e:
+            issues.append(
+                {"type": "timestamp_error", "span_id": span_id, "error": str(e)}
+            )
+
+    return {"valid": len(issues) == 0, "issue_count": len(issues), "issues": issues}
+
+
+@adk_tool
+def build_call_graph(trace_id: str, project_id: str | None = None) -> dict[str, Any]:  # noqa: C901
+    """
+    Builds a hierarchical call graph from the trace spans.
+
+    This function reconstructs the parent-child relationships to form a tree
+    structure, which is useful for structural analysis and visualization.
+
+    Args:
+        trace_id: The unique trace ID.
+        project_id: The Google Cloud Project ID.
+
+    Returns:
+        A dictionary representing the call graph:
+        - root_spans: List of root spans (no parent)
+        - span_tree: Nested dictionary of parent-child relationships
+        - span_names: Set of unique span names in the trace
+        - depth: Maximum depth of the call tree
+    """
+    start_time = time.time()
+    success = True
+
+    with tracer.start_as_current_span("build_call_graph") as span:
+        span.set_attribute("code.function", "build_call_graph")
+
+        log_tool_call(logger, "build_call_graph", trace_id=trace_id)
+
+        try:
+            trace = fetch_trace_data(trace_id, project_id)
+            if "error" in trace:
+                return {"error": trace["error"]}
+
+            spans = trace.get("spans", [])
+
+            # Create lookup maps
+            span_by_id = {}
+            children_by_parent: dict[str, list[str]] = {}
+            root_spans = []
+            span_names: set[str] = set()
+
+            for s in spans:
+                span_id = s.get("span_id")
+                parent_id = s.get("parent_span_id")
+                span_name = s.get("name", "unknown")
+
+                if span_id:
+                    span_by_id[span_id] = s
+
+                span_names.add(span_name)
+
+                if parent_id:
+                    if parent_id not in children_by_parent:
+                        children_by_parent[parent_id] = []
+                    children_by_parent[parent_id].append(span_id)
+                else:
+                    root_spans.append(span_id)
+
+            def build_subtree(span_id: str, depth: int = 0) -> dict[str, Any]:
+                s = span_by_id.get(span_id, {})
+                children_ids = children_by_parent.get(span_id, [])
+
+                return {
+                    "span_id": span_id,
+                    "name": s.get("name", "unknown"),
+                    "depth": depth,
+                    "children": [
+                        build_subtree(child_id, depth + 1) for child_id in children_ids
+                    ],
+                    "labels": s.get("labels", {}),
+                }
+
+            span_tree = [build_subtree(root_id) for root_id in root_spans]
+
+            def get_max_depth(node: dict[str, Any]) -> int:
+                if not node.get("children"):
+                    return node.get("depth", 0)
+                return max(get_max_depth(child) for child in node["children"])
+
+            max_depth = max((get_max_depth(tree) for tree in span_tree), default=0)
+
+            result = {
+                "trace_id": trace.get("trace_id"),
+                "root_spans": root_spans,
+                "span_tree": span_tree,
+                "span_names": list(span_names),
+                "total_spans": len(spans),
+                "max_depth": max_depth,
+            }
+            span.set_attribute("sre_agent.max_depth", max_depth)
+            span.set_attribute("sre_agent.total_spans", len(spans))
+            return result
+
+        except Exception as e:
+            span.record_exception(e)
+            success = False
+            raise e
+        finally:
+            duration_ms = (time.time() - start_time) * 1000
+            _record_telemetry("build_call_graph", success, duration_ms)
+
+
+@adk_tool
+def summarize_trace(trace_id: str, project_id: str | None = None) -> dict[str, Any]:
+    """
+    Creates a summary of a trace to save context window tokens.
+    Extracts high-level stats, top 5 slowest spans, and error spans.
+
+    Args:
+        trace_id: The unique trace ID.
+        project_id: The Google Cloud Project ID.
+    """
+    log_tool_call(logger, "summarize_trace", trace_id=trace_id)
+
+    trace_data = fetch_trace_data(trace_id, project_id)
+    if "error" in trace_data:
+        return trace_data
+
+    spans = trace_data.get("spans", [])
+    duration_ms = trace_data.get("duration_ms", 0)
+
+    # Extract errors
+    errors = []
+    if isinstance(trace_data, dict) and "spans" in trace_data:
+        for s in trace_data["spans"]:
+            if (
+                "error" in str(s.get("labels", {})).lower()
+                or s.get("labels", {}).get("error") == "true"
+            ):
+                errors.append({"span_name": s.get("name"), "error": "Detected"})
+    else:
+        errors = extract_errors(trace_id, project_id)
+
+    # Extract slow spans
+    spans_with_dur = []
+    for s in spans:
+        dur = 0
+        if "duration_ms" in s:
+            dur = s["duration_ms"]
+        elif s.get("start_time") and s.get("end_time"):
+            try:
+                start = datetime.fromisoformat(s["start_time"].replace("Z", "+00:00"))
+                end = datetime.fromisoformat(s["end_time"].replace("Z", "+00:00"))
+                dur = (end - start).total_seconds() * 1000
+            except (ValueError, TypeError):
+                pass
+        spans_with_dur.append({"name": s.get("name"), "duration_ms": dur})
+
+    spans_with_dur.sort(key=lambda x: x["duration_ms"], reverse=True)
+    top_slowest = spans_with_dur[:5]
+
+    return {
+        "trace_id": trace_data.get("trace_id"),
+        "total_spans": len(spans),
+        "duration_ms": duration_ms,
+        "error_count": len(errors),
+        "errors": errors[:5],
+        "slowest_spans": top_slowest,
+    }

--- a/sre_agent/tools/trace/clients.py
+++ b/sre_agent/tools/trace/clients.py
@@ -1,0 +1,576 @@
+"""Cloud Trace API clients for fetching and listing traces."""
+
+import json
+import logging
+import os
+import statistics
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from google.cloud import trace_v1
+
+from ..common import adk_tool
+from ..common.cache import get_data_cache
+
+logger = logging.getLogger(__name__)
+
+
+def _get_project_id() -> str:
+    """Get the GCP project ID from environment."""
+    project_id = os.environ.get("TRACE_PROJECT_ID") or os.environ.get(
+        "GOOGLE_CLOUD_PROJECT"
+    )
+    if not project_id:
+        raise ValueError(
+            "GOOGLE_CLOUD_PROJECT or TRACE_PROJECT_ID environment variable must be set"
+        )
+    return project_id
+
+
+def get_current_time() -> str:
+    """
+    Returns the current UTC time in ISO format.
+    Use this to calculate relative time ranges for list_traces.
+    """
+    return datetime.now(timezone.utc).isoformat()
+
+
+def fetch_trace_data(  # noqa: C901
+    trace_id_or_json: str | dict[str, Any], project_id: str | None = None
+) -> dict[str, Any]:
+    """
+    Helper to fetch trace data by ID or from JSON/dict.
+    Commonly used across analysis tools to handle flexible inputs.
+    """
+    # Check if it's already a dictionary
+    if isinstance(trace_id_or_json, dict):
+        if (
+            "trace_id" in trace_id_or_json
+            or "spans" in trace_id_or_json
+            or "error" in trace_id_or_json
+        ):
+            return trace_id_or_json
+        return {"error": "Invalid trace dictionary provided."}
+
+    # Check if it's a JSON string containing a trace
+    if isinstance(trace_id_or_json, str) and trace_id_or_json.strip().startswith("{"):
+        try:
+            data = json.loads(trace_id_or_json)
+            if isinstance(data, dict):
+                return data
+        except json.JSONDecodeError:
+            return {"error": "Failed to parse trace JSON"}
+
+    if not project_id:
+        try:
+            project_id = _get_project_id()
+        except ValueError:
+            pass
+
+    if not project_id:
+        return {"error": "Project ID required to fetch trace."}
+
+    trace_json = fetch_trace(project_id, trace_id_or_json)
+    try:
+        if isinstance(trace_json, dict):
+            return trace_json
+        data = json.loads(trace_json)
+        if data and "error" in data:
+            return data
+        return data
+    except json.JSONDecodeError:
+        return {"error": "Invalid trace JSON"}
+
+
+@adk_tool
+def fetch_trace(project_id: str, trace_id: str) -> str:
+    """
+    Fetches a specific trace by ID from Cloud Trace API.
+
+    Uses caching to avoid redundant API calls when the same trace
+    is requested multiple times (e.g., by different sub-agents).
+
+    Args:
+        project_id: The Google Cloud Project ID.
+        trace_id: The unique hex ID of the trace.
+
+    Returns:
+        A JSON string representation of the trace, including all spans.
+    """
+    # Check cache first
+    cache = get_data_cache()
+
+    cached = cache.get(f"trace:{trace_id}")
+    if cached:
+        logger.debug(f"Cache hit for trace {trace_id}, skipping API call")
+        return cached
+
+    try:
+        client = trace_v1.TraceServiceClient()
+
+        trace_obj = client.get_trace(project_id=project_id, trace_id=trace_id)
+
+        spans = []
+        trace_start = None
+        trace_end = None
+
+        for span_proto in trace_obj.spans:
+            s_start = span_proto.start_time.timestamp()
+            s_end = span_proto.end_time.timestamp()
+
+            if trace_start is None or s_start < trace_start:
+                trace_start = s_start
+            if trace_end is None or s_end > trace_end:
+                trace_end = s_end
+
+            spans.append(
+                {
+                    "span_id": span_proto.span_id,
+                    "name": span_proto.name,
+                    "start_time": span_proto.start_time.isoformat(),
+                    "end_time": span_proto.end_time.isoformat(),
+                    "parent_span_id": span_proto.parent_span_id,
+                    "labels": dict(span_proto.labels),
+                }
+            )
+
+        duration_ms = (
+            (trace_end - trace_start) * 1000 if trace_start and trace_end else 0
+        )
+
+        result = {
+            "trace_id": trace_obj.trace_id,
+            "project_id": trace_obj.project_id,
+            "spans": spans,
+            "span_count": len(spans),
+            "duration_ms": duration_ms,
+        }
+
+        # Cache the result before returning
+        result_json = json.dumps(result)
+        cache.put(f"trace:{trace_id}", result_json)
+
+        return result_json
+
+    except Exception as e:
+        error_msg = f"Failed to fetch trace: {e!s}"
+        logger.error(error_msg)
+        return json.dumps({"error": error_msg})
+
+
+@adk_tool
+def list_traces(  # noqa: C901
+    project_id: str,
+    start_time: str | None = None,
+    end_time: str | None = None,
+    limit: int = 10,
+    filter_str: str = "",
+    min_latency_ms: int | None = None,
+    error_only: bool = False,
+    attributes: dict[str, str] | None = None,
+) -> str:
+    """
+    Lists recent traces with advanced filtering capabilities.
+
+    Args:
+        project_id: The GCP project ID.
+        start_time: ISO timestamp for start of window.
+        end_time: ISO timestamp for end of window.
+        limit: Max number of traces to return.
+        filter_str: Raw filter string (overrides other filters if provided).
+        min_latency_ms: Minimum latency in milliseconds.
+        error_only: If True, filters for traces with errors.
+        attributes: Dictionary of attribute key-values to filter by.
+
+    Returns:
+        JSON list of trace summaries.
+
+    Example filter_str: 'latency:500ms error:true' or '/http/status_code:500'
+    """
+    # Build filter string if not provided
+    final_filter = filter_str
+    if not final_filter:
+        filters = []
+        if min_latency_ms:
+            filters.append(f"latency:{min_latency_ms}ms")
+
+        if error_only:
+            filters.append("error:true")
+
+        if attributes:
+            for k, v in attributes.items():
+                filters.append(f"{k}:{v}")
+
+        final_filter = " ".join(filters)
+
+    try:
+        client = trace_v1.TraceServiceClient()
+
+        now = datetime.now(timezone.utc)
+        if not end_time:
+            end_dt = now
+        else:
+            end_dt = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
+
+        if not start_time:
+            start_dt = now - timedelta(hours=1)
+        else:
+            start_dt = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
+
+        request = trace_v1.ListTracesRequest(
+            project_id=project_id,
+            start_time=start_dt,
+            end_time=end_dt,
+            page_size=limit,
+            filter=final_filter,
+            view=trace_v1.ListTracesRequest.ViewType.ROOTSPAN,
+        )
+
+        traces = []
+        page_result = client.list_traces(request=request)
+
+        for trace in page_result:
+            duration_ms = 0
+            start_ts = None
+
+            if trace.spans:
+                starts = []
+                ends = []
+                for s in trace.spans:
+                    starts.append(s.start_time.timestamp())
+                    ends.append(s.end_time.timestamp())
+
+                if starts and ends:
+                    start_ts = min(starts)
+                    duration_ms = (max(ends) - start_ts) * 1000
+
+            traces.append(
+                {
+                    "trace_id": trace.trace_id,
+                    "timestamp": datetime.fromtimestamp(
+                        start_ts, tz=timezone.utc
+                    ).isoformat()
+                    if start_ts
+                    else None,
+                    "duration_ms": duration_ms,
+                    "project_id": trace.project_id,
+                }
+            )
+
+            if len(traces) >= limit:
+                break
+
+        return json.dumps(traces)
+
+    except Exception as e:
+        error_msg = f"Failed to list traces: {e!s}"
+        logger.error(error_msg)
+        return json.dumps([{"error": error_msg}])
+
+
+def _calculate_anomaly_score(
+    trace: dict[str, Any],
+    mean_latency: float,
+    stdev_latency: float,
+    has_error: bool = False,
+) -> float:
+    """
+    Calculate a composite anomaly score for a trace.
+
+    The score combines multiple signals:
+    - Latency z-score (how many std devs from mean)
+    - Error presence (significant boost)
+    - Extreme latency bonus (for very slow traces)
+    """
+    score = 0.0
+    duration = trace.get("duration_ms", 0)
+
+    # Z-score component
+    if stdev_latency > 0:
+        z_score = (duration - mean_latency) / stdev_latency
+        score += max(0, z_score)
+    elif duration > mean_latency:
+        score += 3.0
+
+    # Error component
+    if has_error:
+        score += 5.0
+
+    # Extreme latency bonus (>3x mean)
+    if mean_latency > 0 and duration > mean_latency * 3:
+        score += 2.0
+
+    return score
+
+
+def validate_trace(trace_data: str | dict) -> dict[str, Any]:  # noqa: C901
+    """
+    Validates trace data for completeness and quality.
+
+    Checks:
+    - Has required fields (trace_id, spans)
+    - Has valid span structure
+    - Has reasonable duration
+    - Spans have timestamps
+
+    Args:
+        trace_data: Trace data as JSON string or dict.
+
+    Returns:
+        Validation result with 'valid' boolean and 'issues' list.
+    """
+    issues = []
+
+    if isinstance(trace_data, str):
+        try:
+            data = json.loads(trace_data)
+        except json.JSONDecodeError as e:
+            return {"valid": False, "issues": [f"Invalid JSON: {e!s}"]}
+    else:
+        data = trace_data
+
+    if "error" in data:
+        return {"valid": False, "issues": [data["error"]]}
+
+    if not data.get("trace_id"):
+        issues.append("Missing trace_id")
+
+    spans = data.get("spans", [])
+    if not spans:
+        issues.append("No spans in trace")
+    else:
+        for i, span in enumerate(spans):
+            if not span.get("span_id"):
+                issues.append(f"Span {i} missing span_id")
+            if not span.get("name"):
+                issues.append(f"Span {i} missing name")
+            if not span.get("start_time"):
+                issues.append(f"Span {i} missing start_time")
+            if not span.get("end_time"):
+                issues.append(f"Span {i} missing end_time")
+
+        if len(spans) > 1000:
+            issues.append(f"Unusually large trace with {len(spans)} spans")
+
+    duration = data.get("duration_ms", 0)
+    if duration <= 0:
+        issues.append("Invalid or missing duration")
+    elif duration > 300000:
+        issues.append(f"Unusually long duration: {duration}ms")
+
+    return {
+        "valid": len(issues) == 0,
+        "issues": issues,
+        "span_count": len(spans),
+        "duration_ms": duration,
+    }
+
+
+@adk_tool
+def find_example_traces(  # noqa: C901
+    project_id: str | None = None, prefer_errors: bool = True, min_sample_size: int = 20
+) -> str:
+    """
+    Intelligently discovers representative baseline and anomaly traces.
+
+    The algorithm:
+    1. Fetches recent traces to build a statistical model
+    2. Also fetches recent error traces for multi-signal analysis
+    3. Scores traces using composite anomaly scoring
+    4. Validates selected traces before returning
+
+    Args:
+        project_id: GCP project ID. If not provided, uses environment.
+        prefer_errors: If True, error traces get higher anomaly scores.
+        min_sample_size: Minimum traces needed for statistical analysis.
+
+    Returns:
+        JSON string with 'baseline', 'anomaly', 'stats', and 'validation' keys.
+    """
+    try:
+        try:
+            if not project_id:
+                project_id = _get_project_id()
+        except ValueError:
+            return json.dumps({"error": "GOOGLE_CLOUD_PROJECT not set"})
+
+        # Fetch recent traces for statistical baseline
+        raw_traces = list_traces(project_id, limit=50)
+        traces = json.loads(raw_traces)
+
+        if isinstance(traces, list) and len(traces) > 0 and "error" in traces[0]:
+            return raw_traces
+
+        if not traces:
+            return json.dumps({"error": "No traces found in the last hour."})
+
+        # Fetch error traces separately for hybrid selection
+        error_trace_ids = set()
+        if prefer_errors:
+            error_traces_json = list_traces(project_id, limit=10, error_only=True)
+            error_traces = json.loads(error_traces_json)
+            if error_traces and not (
+                isinstance(error_traces, list) and "error" in error_traces[0]
+            ):
+                error_trace_ids = {
+                    t.get("trace_id") for t in error_traces if t.get("trace_id")
+                }
+                existing_ids = {t.get("trace_id") for t in traces}
+                for et in error_traces:
+                    if et.get("trace_id") not in existing_ids:
+                        et["has_error"] = True
+                        traces.append(et)
+
+        # Extract valid traces with latencies
+        valid_traces = [t for t in traces if t.get("duration_ms", 0) > 0]
+        if len(valid_traces) < 2:
+            return json.dumps(
+                {"error": "Insufficient traces with valid duration found."}
+            )
+
+        latencies = [t["duration_ms"] for t in valid_traces]
+        latencies.sort()
+
+        # Calculate statistical metrics
+        p50 = statistics.median(latencies)
+        p95 = (
+            latencies[int(len(latencies) * 0.95)]
+            if len(latencies) > 1
+            else latencies[0]
+        )
+        p99 = (
+            latencies[int(len(latencies) * 0.99)]
+            if len(latencies) > 1
+            else latencies[0]
+        )
+        mean = statistics.mean(latencies)
+        stdev = statistics.stdev(latencies) if len(latencies) > 1 else 0
+
+        # Score all traces for anomaly detection
+        for trace in valid_traces:
+            has_error = (
+                trace.get("has_error", False)
+                or trace.get("trace_id") in error_trace_ids
+            )
+            trace["_anomaly_score"] = _calculate_anomaly_score(
+                trace, mean, stdev, has_error
+            )
+            trace["_has_error"] = has_error
+
+        # Select baseline (closest to P50, prefer no errors)
+        baseline_candidates = [
+            t for t in valid_traces if not t.get("_has_error", False)
+        ]
+        if not baseline_candidates:
+            baseline_candidates = valid_traces
+
+        baseline = min(baseline_candidates, key=lambda x: abs(x["duration_ms"] - p50))
+
+        # Select anomaly (highest anomaly score, excluding baseline)
+        anomaly_candidates = [
+            t for t in valid_traces if t.get("trace_id") != baseline.get("trace_id")
+        ]
+        if anomaly_candidates:
+            anomaly = max(anomaly_candidates, key=lambda x: x.get("_anomaly_score", 0))
+        else:
+            anomaly = max(valid_traces, key=lambda x: x.get("duration_ms", 0))
+
+        # Add selection reasoning
+        baseline["_selection_reason"] = f"Closest to P50 ({p50:.1f}ms)"
+        anomaly_score = anomaly.get("_anomaly_score", 0)
+        if anomaly.get("_has_error"):
+            anomaly["_selection_reason"] = (
+                f"Error trace with anomaly score {anomaly_score:.2f}"
+            )
+        else:
+            anomaly["_selection_reason"] = (
+                f"High latency anomaly score {anomaly_score:.2f}"
+            )
+
+        # Clean up internal fields
+        for trace in [baseline, anomaly]:
+            trace.pop("_anomaly_score", None)
+            trace.pop("_has_error", None)
+
+        validation = {
+            "baseline_valid": baseline.get("trace_id") is not None,
+            "anomaly_valid": anomaly.get("trace_id") is not None,
+            "sample_adequate": len(valid_traces) >= min_sample_size,
+            "latency_variance_detected": stdev > 0,
+        }
+
+        return json.dumps(
+            {
+                "stats": {
+                    "count": len(valid_traces),
+                    "p50_ms": round(p50, 2),
+                    "p95_ms": round(p95, 2),
+                    "p99_ms": round(p99, 2),
+                    "mean_ms": round(mean, 2),
+                    "stdev_ms": round(stdev, 2) if stdev else 0,
+                    "error_traces_found": len(error_trace_ids),
+                },
+                "baseline": baseline,
+                "anomaly": anomaly,
+                "validation": validation,
+                "selection_method": "hybrid_multi_signal",
+            }
+        )
+
+    except Exception as e:
+        error_msg = f"Failed to find example traces: {e!s}"
+        logger.error(error_msg)
+        return json.dumps({"error": error_msg})
+
+
+@adk_tool
+def get_trace_by_url(url: str) -> str:  # noqa: C901
+    """
+    Parses a Cloud Console URL to extract trace ID and fetch the trace.
+
+    Args:
+        url: The full URL from Google Cloud Console trace view.
+
+    Returns:
+        The fetched trace data as JSON.
+    """
+    try:
+        from urllib.parse import parse_qs, urlparse
+
+        parsed = urlparse(url)
+        params = parse_qs(parsed.query)
+
+        project_id = params.get("project", [None])[0]
+
+        trace_id = None
+        if "tid" in params:
+            trace_id = params["tid"][0]
+        elif "details" in parsed.path:
+            parts = parsed.path.split("/")
+            for i, part in enumerate(parts):
+                if "details" in part and i + 1 < len(parts):
+                    trace_id = parts[i + 1]
+                    break
+
+        # Fallback: look for hex ID in path
+        if not trace_id:
+            for part in reversed(parsed.path.split("/")):
+                if (
+                    part
+                    and all(c in "0123456789abcdefABCDEF" for c in part)
+                    and len(part) >= 32
+                ):
+                    trace_id = part
+                    break
+
+        if not project_id or not trace_id:
+            return json.dumps(
+                {"error": "Could not parse project_id or trace_id from URL"}
+            )
+
+        return fetch_trace(project_id, trace_id)
+
+    except Exception as e:
+        error_msg = f"Failed to get trace by URL: {e!s}"
+        logger.error(error_msg)
+        return json.dumps({"error": error_msg})

--- a/sre_agent/tools/trace/comparison.py
+++ b/sre_agent/tools/trace/comparison.py
@@ -1,0 +1,404 @@
+"""Trace comparison utilities for diff analysis between traces."""
+
+import logging
+import time
+from datetime import datetime
+from typing import Any
+
+from ..common.telemetry import get_meter, get_tracer, log_tool_call
+from ..common import adk_tool
+from .analysis import calculate_span_durations, build_call_graph
+
+logger = logging.getLogger(__name__)
+
+# Telemetry setup
+tracer = get_tracer(__name__)
+meter = get_meter(__name__)
+
+execution_duration = meter.create_histogram(
+    name="sre_agent.comparison.execution_duration",
+    description="Duration of comparison operations",
+    unit="ms",
+)
+execution_count = meter.create_counter(
+    name="sre_agent.comparison.execution_count",
+    description="Total number of comparison operations",
+    unit="1",
+)
+anomalies_detected = meter.create_counter(
+    name="sre_agent.comparison.anomalies_detected",
+    description="Count of differences found",
+    unit="1",
+)
+
+
+def _record_telemetry(func_name: str, success: bool = True, duration_ms: float = 0.0):
+    attributes = {
+        "code.function": func_name,
+        "success": str(success).lower(),
+    }
+    execution_count.add(1, attributes)
+    execution_duration.record(duration_ms, attributes)
+
+
+SpanData = dict[str, Any]
+
+
+@adk_tool
+def compare_span_timings(  # noqa: C901
+    baseline_trace_id: str,
+    target_trace_id: str,
+    project_id: str | None = None,
+) -> dict[str, Any]:
+    """
+    Compares timing between spans in two traces and detects performance anti-patterns.
+
+    Args:
+        baseline_trace_id: The ID of the reference/normal trace.
+        target_trace_id: The ID of the trace being analyzed.
+        project_id: The Google Cloud Project ID.
+
+    Returns:
+        A comparison report with:
+        - slower_spans: Spans that got slower in target
+        - faster_spans: Spans that got faster in target
+        - missing_from_target: Spans in baseline but not in target
+        - new_in_target: Spans in target but not in baseline
+        - patterns: Detected anti-patterns (N+1 queries, serial chains)
+        - summary: Overall timing comparison summary
+    """
+    start_time = time.time()
+    success = True
+
+    with tracer.start_as_current_span("compare_span_timings") as span:
+        span.set_attribute("code.function", "compare_span_timings")
+
+        log_tool_call(
+            logger,
+            "compare_span_timings",
+            baseline_trace_id=baseline_trace_id,
+            target_trace_id=target_trace_id,
+        )
+
+        try:
+            baseline_timings = calculate_span_durations(baseline_trace_id, project_id)
+            target_timings = calculate_span_durations(target_trace_id, project_id)
+
+            if (
+                baseline_timings
+                and isinstance(baseline_timings[0], dict)
+                and "error" in baseline_timings[0]
+            ):
+                return {
+                    "error": f"Baseline trace error: {baseline_timings[0]['error']}"
+                }
+            if (
+                target_timings
+                and isinstance(target_timings[0], dict)
+                and "error" in target_timings[0]
+            ):
+                return {"error": f"Target trace error: {target_timings[0]['error']}"}
+
+            # Anti-Pattern Detection
+            patterns = []
+
+            # N+1 Query Detection
+            if target_timings:
+                sorted_spans = sorted(
+                    [s for s in target_timings if s.get("start_time")],
+                    key=lambda x: x["start_time"],
+                )
+
+                if sorted_spans:
+                    current_run = []
+                    for s in sorted_spans:
+                        if not current_run:
+                            current_run.append(s)
+                        else:
+                            if s.get("name") == current_run[-1].get("name"):
+                                current_run.append(s)
+                            else:
+                                if len(current_run) >= 3:
+                                    duration_sum = sum(
+                                        s.get("duration_ms") or 0 for s in current_run
+                                    )
+                                    if duration_sum > 50:
+                                        patterns.append(
+                                            {
+                                                "type": "n_plus_one",
+                                                "description": f"Potential N+1 Query: '{current_run[0].get('name')}' called {len(current_run)} times sequentially.",
+                                                "span_name": current_run[0].get("name"),
+                                                "count": len(current_run),
+                                                "total_duration_ms": duration_sum,
+                                                "impact": "high" if duration_sum > 200 else "medium",
+                                            }
+                                        )
+                                current_run = [s]
+
+                    # Check last run
+                    if len(current_run) >= 3:
+                        duration_sum = sum(
+                            s.get("duration_ms") or 0 for s in current_run
+                        )
+                        if duration_sum > 50:
+                            patterns.append(
+                                {
+                                    "type": "n_plus_one",
+                                    "description": f"Potential N+1 Query: '{current_run[0].get('name')}' called {len(current_run)} times sequentially.",
+                                    "span_name": current_run[0].get("name"),
+                                    "count": len(current_run),
+                                    "total_duration_ms": duration_sum,
+                                    "impact": "high" if duration_sum > 200 else "medium",
+                                }
+                            )
+
+            # Serial Chain Detection
+            if target_timings and sorted_spans:
+                sequential_chains = []
+                current_chain = []
+                gap_threshold_ms = 10
+
+                for i in range(len(sorted_spans) - 1):
+                    curr_span = sorted_spans[i]
+                    next_span = sorted_spans[i + 1]
+
+                    if not (curr_span.get("end_time") and next_span.get("start_time")):
+                        continue
+
+                    try:
+                        curr_end = (
+                            datetime.fromisoformat(
+                                curr_span["end_time"].replace("Z", "+00:00")
+                            ).timestamp()
+                            * 1000
+                        )
+                        next_start = (
+                            datetime.fromisoformat(
+                                next_span["start_time"].replace("Z", "+00:00")
+                            ).timestamp()
+                            * 1000
+                        )
+
+                        is_parent_child = curr_span.get("span_id") == next_span.get(
+                            "parent_span_id"
+                        ) or next_span.get("span_id") == curr_span.get("parent_span_id")
+
+                        if is_parent_child:
+                            if len(current_chain) >= 3:
+                                sequential_chains.append(current_chain[:])
+                            current_chain = []
+                            continue
+
+                        gap = next_start - curr_end
+
+                        if gap >= 0 and gap <= gap_threshold_ms:
+                            if not current_chain:
+                                current_chain.append(curr_span)
+                            current_chain.append(next_span)
+                        else:
+                            if len(current_chain) >= 3:
+                                sequential_chains.append(current_chain[:])
+                            current_chain = []
+
+                    except (ValueError, TypeError, KeyError):
+                        continue
+
+                if len(current_chain) >= 3:
+                    sequential_chains.append(current_chain[:])
+
+                for chain in sequential_chains:
+                    chain_duration = sum(s.get("duration_ms") or 0 for s in chain)
+
+                    if chain_duration > 100:
+                        span_names = [s.get("name") for s in chain]
+                        patterns.append(
+                            {
+                                "type": "serial_chain",
+                                "description": f"Serial Chain: {len(chain)} operations running sequentially that could potentially be parallelized.",
+                                "span_names": span_names,
+                                "count": len(chain),
+                                "total_duration_ms": round(chain_duration, 2),
+                                "impact": "high" if chain_duration > 500 else "medium",
+                                "recommendation": "Consider parallelizing these operations using async/await or concurrent execution.",
+                            }
+                        )
+
+            # Compare spans by name
+            baseline_by_name: dict[str, list[SpanData]] = {}
+            for s in baseline_timings:
+                name = s.get("name")
+                if name:
+                    if name not in baseline_by_name:
+                        baseline_by_name[name] = []
+                    baseline_by_name[name].append(s)
+
+            target_by_name: dict[str, list[SpanData]] = {}
+            for s in target_timings:
+                name = s.get("name")
+                if name:
+                    if name not in target_by_name:
+                        target_by_name[name] = []
+                    target_by_name[name].append(s)
+
+            slower_spans = []
+            faster_spans = []
+
+            all_names = set(baseline_by_name.keys()) | set(target_by_name.keys())
+
+            for name in all_names:
+                baseline_spans = baseline_by_name.get(name, [])
+                target_spans = target_by_name.get(name, [])
+
+                if baseline_spans and target_spans:
+                    baseline_avg = sum(
+                        s.get("duration_ms") or 0 for s in baseline_spans
+                    ) / len(baseline_spans)
+                    target_avg = sum(
+                        s.get("duration_ms") or 0 for s in target_spans
+                    ) / len(target_spans)
+
+                    diff_ms = target_avg - baseline_avg
+                    diff_pct = (diff_ms / baseline_avg * 100) if baseline_avg > 0 else 0
+
+                    comparison = {
+                        "span_name": name,
+                        "baseline_duration_ms": round(baseline_avg, 2),
+                        "target_duration_ms": round(target_avg, 2),
+                        "diff_ms": round(diff_ms, 2),
+                        "diff_percent": round(diff_pct, 1),
+                        "baseline_count": len(baseline_spans),
+                        "target_count": len(target_spans),
+                    }
+
+                    if diff_pct > 10 or diff_ms > 50:
+                        slower_spans.append(comparison)
+                    elif diff_pct < -10 or diff_ms < -50:
+                        faster_spans.append(comparison)
+
+            slower_spans.sort(key=lambda x: x["diff_ms"], reverse=True)
+            faster_spans.sort(key=lambda x: x["diff_ms"])
+
+            missing_from_target = [
+                name for name in baseline_by_name if name not in target_by_name
+            ]
+            new_in_target = [
+                name for name in target_by_name if name not in baseline_by_name
+            ]
+
+            baseline_total = sum(s.get("duration_ms") or 0 for s in baseline_timings)
+            target_total = sum(s.get("duration_ms") or 0 for s in target_timings)
+
+            result = {
+                "slower_spans": slower_spans,
+                "faster_spans": faster_spans,
+                "missing_from_target": missing_from_target,
+                "new_in_target": new_in_target,
+                "patterns": patterns,
+                "summary": {
+                    "baseline_total_ms": round(baseline_total, 2),
+                    "target_total_ms": round(target_total, 2),
+                    "total_diff_ms": round(target_total - baseline_total, 2),
+                    "num_slower": len(slower_spans),
+                    "num_faster": len(faster_spans),
+                },
+            }
+            span.set_attribute("sre_agent.slower_spans_count", len(slower_spans))
+            anomalies_detected.add(len(slower_spans), {"type": "slow_span"})
+
+            return result
+        except Exception as e:
+            span.record_exception(e)
+            success = False
+            raise e
+        finally:
+            duration_ms = (time.time() - start_time) * 1000
+            _record_telemetry("compare_span_timings", success, duration_ms)
+
+
+@adk_tool
+def find_structural_differences(
+    baseline_trace_id: str,
+    target_trace_id: str,
+    project_id: str | None = None,
+) -> dict[str, Any]:
+    """
+    Compares the call graph structure between two traces.
+
+    Args:
+        baseline_trace_id: The ID of the reference/normal trace.
+        target_trace_id: The ID of the trace being analyzed.
+        project_id: The Google Cloud Project ID.
+
+    Returns:
+        A structural comparison with:
+        - missing_spans: Span names present in baseline but not target
+        - new_spans: Span names present in target but not baseline
+        - depth_change: Change in call tree depth
+        - fan_out_changes: Changes in number of child calls
+    """
+    start_time = time.time()
+    success = True
+
+    with tracer.start_as_current_span("find_structural_differences") as span:
+        span.set_attribute("code.function", "find_structural_differences")
+
+        log_tool_call(
+            logger,
+            "find_structural_differences",
+            baseline_trace_id=baseline_trace_id,
+            target_trace_id=target_trace_id,
+        )
+
+        try:
+            baseline_graph = build_call_graph(baseline_trace_id, project_id)
+            target_graph = build_call_graph(target_trace_id, project_id)
+
+            if "error" in baseline_graph:
+                return {"error": f"Baseline trace error: {baseline_graph['error']}"}
+            if "error" in target_graph:
+                return {"error": f"Target trace error: {target_graph['error']}"}
+
+            baseline_names = set(baseline_graph.get("span_names", []))
+            target_names = set(target_graph.get("span_names", []))
+
+            missing_spans = list(baseline_names - target_names)
+            new_spans = list(target_names - baseline_names)
+            common_spans = list(baseline_names & target_names)
+
+            depth_change = target_graph.get("max_depth", 0) - baseline_graph.get(
+                "max_depth", 0
+            )
+
+            result = {
+                "missing_spans": missing_spans,
+                "new_spans": new_spans,
+                "common_spans": common_spans,
+                "baseline_span_count": baseline_graph.get("total_spans", 0),
+                "target_span_count": target_graph.get("total_spans", 0),
+                "span_count_change": target_graph.get("total_spans", 0)
+                - baseline_graph.get("total_spans", 0),
+                "baseline_depth": baseline_graph.get("max_depth", 0),
+                "target_depth": target_graph.get("max_depth", 0),
+                "depth_change": depth_change,
+                "summary": {
+                    "spans_removed": len(missing_spans),
+                    "spans_added": len(new_spans),
+                    "structure_changed": len(missing_spans) > 0
+                    or len(new_spans) > 0
+                    or depth_change != 0,
+                },
+            }
+
+            change_count = len(missing_spans) + len(new_spans)
+            anomalies_detected.add(change_count, {"type": "structural_change"})
+            if depth_change != 0:
+                anomalies_detected.add(1, {"type": "depth_change"})
+
+            return result
+        except Exception as e:
+            span.record_exception(e)
+            success = False
+            raise e
+        finally:
+            duration_ms = (time.time() - start_time) * 1000
+            _record_telemetry("find_structural_differences", success, duration_ms)

--- a/sre_agent/tools/trace/filters.py
+++ b/sre_agent/tools/trace/filters.py
@@ -1,0 +1,274 @@
+"""Trace filter utilities for building Cloud Trace query strings."""
+
+import numpy as np
+
+from ..common import adk_tool
+
+
+class TraceSelector:
+    """
+    Provides different strategies for selecting traces for analysis.
+    """
+
+    def from_error_reports(self, project_id: str) -> list[str]:
+        """
+        Selects traces associated with recent error reports.
+        (Placeholder - requires Error Reporting API client)
+        """
+        print("Warning: Trace selection from error reports is not yet implemented.")
+        return []
+
+    def from_monitoring_alerts(self, project_id: str) -> list[str]:
+        """
+        Selects traces associated with active monitoring alerts.
+        (Placeholder - requires Monitoring API client)
+        """
+        print("Warning: Trace selection from monitoring alerts is not yet implemented.")
+        return []
+
+    def from_statistical_outliers(self, traces: list[dict]) -> list[str]:
+        """
+        Selects traces that are statistical outliers based on latency.
+        An outlier is defined as a trace with a latency greater than 2 standard
+        deviations from the mean.
+        """
+        if not traces:
+            return []
+
+        latencies = [trace.get("latency", 0) for trace in traces]
+        mean_latency = np.mean(latencies)
+        std_dev_latency = np.std(latencies)
+        threshold = mean_latency + 2 * std_dev_latency
+
+        outlier_trace_ids = [
+            trace["traceId"] for trace in traces if trace.get("latency", 0) > threshold
+        ]
+        return outlier_trace_ids
+
+    def from_manual_override(self, trace_ids: list[str]) -> list[str]:
+        """
+        Allows manually specifying a list of trace IDs.
+        """
+        return trace_ids
+
+
+@adk_tool
+def select_traces_from_error_reports(project_id: str) -> list[str]:
+    """
+    Selects traces to analyze based on recent error reports.
+
+    Args:
+        project_id: The Google Cloud project ID.
+
+    Returns:
+        A list of trace IDs.
+    """
+    selector = TraceSelector()
+    return selector.from_error_reports(project_id)
+
+
+@adk_tool
+def select_traces_from_monitoring_alerts(project_id: str) -> list[str]:
+    """
+    Selects traces to analyze based on active monitoring alerts.
+
+    Args:
+        project_id: The Google Cloud project ID.
+
+    Returns:
+        A list of trace IDs.
+    """
+    selector = TraceSelector()
+    return selector.from_monitoring_alerts(project_id)
+
+
+@adk_tool
+def select_traces_from_statistical_outliers(traces: list[dict]) -> list[str]:
+    """
+    Selects outlier traces from a given list of traces based on latency.
+
+    Args:
+        traces: A list of trace dictionaries, each with a 'latency' and 'traceId'.
+
+    Returns:
+        A list of outlier trace IDs.
+    """
+    selector = TraceSelector()
+    return selector.from_statistical_outliers(traces)
+
+
+@adk_tool
+def select_traces_manually(trace_ids: list[str]) -> list[str]:
+    """
+    Allows a user to manually provide a list of trace IDs for analysis.
+
+    Args:
+        trace_ids: A list of trace IDs.
+
+    Returns:
+        The same list of trace IDs.
+    """
+    selector = TraceSelector()
+    return selector.from_manual_override(trace_ids)
+
+
+class TraceQueryBuilder:
+    """
+    Builder for Google Cloud Trace filter strings.
+
+    See: https://docs.cloud.google.com/trace/docs/trace-filters
+    """
+
+    def __init__(self):
+        self._terms: list[str] = []
+
+    def _add_term(self, term: str, root_only: bool = False):
+        if root_only:
+            self._terms.append(f"^{term}")
+        else:
+            self._terms.append(term)
+
+    def span_name(
+        self, name: str, match_exact: bool = False, root_only: bool = False
+    ) -> "TraceQueryBuilder":
+        """
+        Filter by span name.
+
+        Args:
+            name: The span name to filter for.
+            match_exact: If True, uses `+span:name`.
+            root_only: If True, restricts to root span.
+        """
+        prefix = "+" if match_exact else ""
+
+        if root_only:
+            term = f"root:{name}"
+        else:
+            term = f"span:{name}"
+
+        self._terms.append(f"{prefix}{term}")
+        return self
+
+    def latency(
+        self, min_latency_ms: int | None = None, max_latency_ms: int | None = None
+    ) -> "TraceQueryBuilder":
+        """
+        Filter by latency.
+
+        Args:
+            min_latency_ms: Minimum latency in milliseconds.
+            max_latency_ms: Maximum latency (not directly supported).
+        """
+        if min_latency_ms is not None:
+            self._terms.append(f"latency:{min_latency_ms}ms")
+
+        return self
+
+    def attribute(
+        self, key: str, value: str, match_exact: bool = False, root_only: bool = False
+    ) -> "TraceQueryBuilder":
+        """
+        Filter by attribute (label) key/value.
+
+        Args:
+            key: Attribute key (e.g. '/http/status_code').
+            value: Attribute value.
+            match_exact: If True, requires exact match.
+            root_only: If True, restricts to root span.
+        """
+        term = f"{key}:{value}"
+
+        prefix = ""
+        if match_exact:
+            prefix += "+"
+        if root_only:
+            prefix += "^"
+
+        self._terms.append(f"{prefix}{term}")
+        return self
+
+    def service_name(self, name: str, match_exact: bool = False) -> "TraceQueryBuilder":
+        """Helper for service name filtering."""
+        return self.attribute("service.name", name, match_exact=match_exact)
+
+    def status(self, code: int, root_only: bool = False) -> "TraceQueryBuilder":
+        """Filter by HTTP status code."""
+        return self.attribute("/http/status_code", str(code), root_only=root_only)
+
+    def method(self, method: str, root_only: bool = False) -> "TraceQueryBuilder":
+        """Filter by HTTP method."""
+        term = f"method:{method}"
+        if root_only:
+            term = f"^{term}"
+        self._terms.append(term)
+        return self
+
+    def url(self, url: str, root_only: bool = False) -> "TraceQueryBuilder":
+        """Filter by URL."""
+        term = f"url:{url}"
+        if root_only:
+            term = f"^{term}"
+        self._terms.append(term)
+        return self
+
+    def build(self) -> str:
+        """Returns the constructed filter string."""
+        return " ".join(self._terms)
+
+    def clear(self):
+        self._terms = []
+
+
+def build_trace_filter(
+    min_latency_ms: int | None = None,
+    max_latency_ms: int | None = None,
+    error_only: bool = False,
+    service_name: str | None = None,
+    http_status: int | None = None,
+    attributes: dict[str, str] | None = None,
+    custom_filter: str | None = None,
+) -> str:
+    """
+    Build Cloud Trace filter string using TraceQueryBuilder.
+
+    This is a convenience function that simplifies creating trace filters
+    for common use cases.
+
+    Args:
+        min_latency_ms: Minimum latency in milliseconds.
+        max_latency_ms: Maximum latency in milliseconds (not widely supported).
+        error_only: If True, filters for traces with errors.
+        service_name: Filter by service name.
+        http_status: Filter by HTTP status code.
+        attributes: Dictionary of attribute key-value pairs to filter by.
+        custom_filter: If provided, returns this instead of building a new filter.
+
+    Returns:
+        Cloud Trace filter string.
+
+    Example:
+        >>> build_trace_filter(min_latency_ms=500, error_only=True)
+        'latency:500ms error:true'
+    """
+    if custom_filter:
+        return custom_filter
+
+    builder = TraceQueryBuilder()
+
+    if min_latency_ms or max_latency_ms:
+        builder.latency(min_latency_ms=min_latency_ms, max_latency_ms=max_latency_ms)
+
+    if error_only:
+        builder.attribute("error", "true")
+
+    if service_name:
+        builder.service_name(service_name)
+
+    if http_status:
+        builder.status(http_status)
+
+    if attributes:
+        for k, v in attributes.items():
+            builder.attribute(k, v)
+
+    return builder.build()


### PR DESCRIPTION
Major refactoring to make the agent more generic and reusable:

- Renamed from trace_analyzer to sre_agent
- Reorganized tools into modular subdirectories:
  - tools/common/ - Shared utilities (decorators, telemetry, cache)
  - tools/gcp/ - GCP MCP and direct API clients
  - tools/trace/ - Trace analysis tools
  - tools/bigquery/ - BigQuery OTel analysis tools
- Added MCP support for Cloud Logging and Cloud Monitoring
- Updated sub-agents for trace analysis specialization
- Updated schemas for broader observability support
- Updated README and pyproject.toml

The agent now supports:
- Distributed trace analysis (primary specialization)
- Log analysis via Cloud Logging
- Metrics analysis via Cloud Monitoring
- BigQuery-based aggregate analysis

The original trace_analyzer package is preserved for backwards compatibility.