### PR TITLE
Add configurable tool enable/disable feature

### DIFF
--- a/autosre/lib/pages/conversation_page.dart
+++ b/autosre/lib/pages/conversation_page.dart
@@ -8,6 +8,7 @@ import '../agent/adk_content_generator.dart';
 import '../catalog.dart';
 import '../services/project_service.dart';
 import '../theme/app_theme.dart';
+import 'tool_config_page.dart';
 
 class ConversationPage extends StatefulWidget {
   const ConversationPage({super.key});
@@ -254,11 +255,48 @@ class _ConversationPageState extends State<ConversationPage>
                             );
                           },
                         ),
+                        const SizedBox(width: 8),
+                        // Tool Configuration button
+                        _buildToolConfigButton(compact: isMobile),
                       ],
                     ),
                   );
                 },
               ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildToolConfigButton({bool compact = false}) {
+    return Material(
+      color: Colors.transparent,
+      child: InkWell(
+        onTap: () {
+          Navigator.of(context).push(
+            MaterialPageRoute(
+              builder: (context) => const ToolConfigPage(),
+            ),
+          );
+        },
+        borderRadius: BorderRadius.circular(10),
+        child: Container(
+          padding: EdgeInsets.all(compact ? 6 : 8),
+          decoration: BoxDecoration(
+            color: Colors.white.withValues(alpha: 0.05),
+            borderRadius: BorderRadius.circular(10),
+            border: Border.all(
+              color: AppColors.surfaceBorder,
+            ),
+          ),
+          child: Tooltip(
+            message: 'Tool Configuration',
+            child: Icon(
+              Icons.build_outlined,
+              size: compact ? 16 : 18,
+              color: AppColors.textMuted,
             ),
           ),
         ),

--- a/autosre/lib/pages/tool_config_page.dart
+++ b/autosre/lib/pages/tool_config_page.dart
@@ -1,0 +1,559 @@
+import 'package:flutter/material.dart';
+import '../services/tool_config_service.dart';
+import '../theme/app_theme.dart';
+
+/// A page for configuring which tools the agent can use.
+class ToolConfigPage extends StatefulWidget {
+  const ToolConfigPage({super.key});
+
+  @override
+  State<ToolConfigPage> createState() => _ToolConfigPageState();
+}
+
+class _ToolConfigPageState extends State<ToolConfigPage>
+    with SingleTickerProviderStateMixin {
+  final ToolConfigService _service = ToolConfigService();
+  late TabController _tabController;
+  bool _isTestingAll = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _tabController = TabController(
+      length: ToolCategory.values.length,
+      vsync: this,
+    );
+    _service.fetchConfigs();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: AppColors.backgroundDark,
+      appBar: AppBar(
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+        title: const Text('Tool Configuration'),
+        actions: [
+          // Test All button
+          Padding(
+            padding: const EdgeInsets.only(right: 8),
+            child: _isTestingAll
+                ? const SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor:
+                          AlwaysStoppedAnimation<Color>(AppColors.primaryTeal),
+                    ),
+                  )
+                : IconButton(
+                    icon: const Icon(Icons.play_circle_outline),
+                    tooltip: 'Test All Testable Tools',
+                    onPressed: _testAllTools,
+                  ),
+          ),
+          // Refresh button
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            tooltip: 'Refresh',
+            onPressed: () => _service.fetchConfigs(),
+          ),
+        ],
+        bottom: PreferredSize(
+          preferredSize: const Size.fromHeight(48),
+          child: _buildTabBar(),
+        ),
+      ),
+      body: Column(
+        children: [
+          _buildSummaryBar(),
+          Expanded(
+            child: _buildTabContent(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildTabBar() {
+    return TabBar(
+      controller: _tabController,
+      isScrollable: true,
+      indicatorColor: AppColors.primaryTeal,
+      labelColor: AppColors.textPrimary,
+      unselectedLabelColor: AppColors.textMuted,
+      tabAlignment: TabAlignment.start,
+      tabs: ToolCategory.values.map((category) {
+        return Tab(
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(_getCategoryIcon(category), size: 18),
+              const SizedBox(width: 8),
+              Text(category.displayName),
+            ],
+          ),
+        );
+      }).toList(),
+    );
+  }
+
+  Widget _buildSummaryBar() {
+    return ValueListenableBuilder<ToolConfigSummary?>(
+      valueListenable: _service.summary,
+      builder: (context, summary, _) {
+        if (summary == null) {
+          return const SizedBox.shrink();
+        }
+
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 12),
+          decoration: BoxDecoration(
+            color: AppColors.backgroundCard,
+            border: Border(
+              bottom: BorderSide(
+                color: AppColors.surfaceBorder,
+                width: 1,
+              ),
+            ),
+          ),
+          child: Row(
+            mainAxisAlignment: MainAxisAlignment.spaceAround,
+            children: [
+              _buildSummaryItem(
+                'Total',
+                summary.total.toString(),
+                AppColors.textSecondary,
+              ),
+              _buildSummaryItem(
+                'Enabled',
+                summary.enabled.toString(),
+                AppColors.success,
+              ),
+              _buildSummaryItem(
+                'Disabled',
+                summary.disabled.toString(),
+                AppColors.error,
+              ),
+              _buildSummaryItem(
+                'Testable',
+                summary.testable.toString(),
+                AppColors.info,
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildSummaryItem(String label, String value, Color color) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        Text(
+          value,
+          style: TextStyle(
+            fontSize: 20,
+            fontWeight: FontWeight.bold,
+            color: color,
+          ),
+        ),
+        Text(
+          label,
+          style: TextStyle(
+            fontSize: 12,
+            color: AppColors.textMuted,
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildTabContent() {
+    return ValueListenableBuilder<bool>(
+      valueListenable: _service.isLoading,
+      builder: (context, isLoading, _) {
+        if (isLoading) {
+          return const Center(
+            child: CircularProgressIndicator(
+              valueColor: AlwaysStoppedAnimation<Color>(AppColors.primaryTeal),
+            ),
+          );
+        }
+
+        return ValueListenableBuilder<String?>(
+          valueListenable: _service.error,
+          builder: (context, error, _) {
+            if (error != null) {
+              return Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Icon(
+                      Icons.error_outline,
+                      size: 48,
+                      color: AppColors.error,
+                    ),
+                    const SizedBox(height: 16),
+                    Text(
+                      error,
+                      style: TextStyle(color: AppColors.textSecondary),
+                    ),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () => _service.fetchConfigs(),
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            return TabBarView(
+              controller: _tabController,
+              children: ToolCategory.values.map((category) {
+                return _buildCategoryContent(category);
+              }).toList(),
+            );
+          },
+        );
+      },
+    );
+  }
+
+  Widget _buildCategoryContent(ToolCategory category) {
+    return ValueListenableBuilder<Map<ToolCategory, List<ToolConfig>>>(
+      valueListenable: _service.toolsByCategory,
+      builder: (context, toolsByCategory, _) {
+        final tools = toolsByCategory[category] ?? [];
+
+        if (tools.isEmpty) {
+          return Center(
+            child: Text(
+              'No tools in this category',
+              style: TextStyle(color: AppColors.textMuted),
+            ),
+          );
+        }
+
+        return Column(
+          children: [
+            _buildCategoryActions(category, tools),
+            Expanded(
+              child: ListView.builder(
+                padding: const EdgeInsets.all(16),
+                itemCount: tools.length,
+                itemBuilder: (context, index) {
+                  return _buildToolCard(tools[index]);
+                },
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  Widget _buildCategoryActions(ToolCategory category, List<ToolConfig> tools) {
+    final enabledCount = tools.where((t) => t.enabled).length;
+    final testableCount = tools.where((t) => t.testable).length;
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+      decoration: BoxDecoration(
+        color: Colors.white.withValues(alpha: 0.03),
+      ),
+      child: Row(
+        children: [
+          Text(
+            '${tools.length} tools ($enabledCount enabled, $testableCount testable)',
+            style: TextStyle(
+              color: AppColors.textSecondary,
+              fontSize: 13,
+            ),
+          ),
+          const Spacer(),
+          TextButton.icon(
+            onPressed: () => _service.enableCategory(category),
+            icon: const Icon(Icons.check_circle_outline, size: 18),
+            label: const Text('Enable All'),
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.success,
+            ),
+          ),
+          const SizedBox(width: 8),
+          TextButton.icon(
+            onPressed: () => _service.disableCategory(category),
+            icon: const Icon(Icons.cancel_outlined, size: 18),
+            label: const Text('Disable All'),
+            style: TextButton.styleFrom(
+              foregroundColor: AppColors.error,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildToolCard(ToolConfig tool) {
+    return ValueListenableBuilder<Set<String>>(
+      valueListenable: _service.testingTools,
+      builder: (context, testingTools, _) {
+        final isTesting = testingTools.contains(tool.name);
+
+        return Container(
+          margin: const EdgeInsets.only(bottom: 12),
+          decoration: GlassDecoration.card(
+            borderRadius: 12,
+            borderColor: tool.enabled
+                ? AppColors.success.withValues(alpha: 0.3)
+                : AppColors.surfaceBorder,
+          ),
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              children: [
+                Row(
+                  children: [
+                    Expanded(
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Text(
+                            tool.displayName,
+                            style: const TextStyle(
+                              fontSize: 16,
+                              fontWeight: FontWeight.w600,
+                              color: AppColors.textPrimary,
+                            ),
+                          ),
+                          const SizedBox(height: 4),
+                          Text(
+                            tool.name,
+                            style: TextStyle(
+                              fontSize: 12,
+                              color: AppColors.textMuted,
+                              fontFamily: 'monospace',
+                            ),
+                          ),
+                        ],
+                      ),
+                    ),
+                    // Test button for testable tools
+                    if (tool.testable) ...[
+                      isTesting
+                          ? const SizedBox(
+                              width: 24,
+                              height: 24,
+                              child: CircularProgressIndicator(
+                                strokeWidth: 2,
+                                valueColor: AlwaysStoppedAnimation<Color>(
+                                  AppColors.info,
+                                ),
+                              ),
+                            )
+                          : IconButton(
+                              icon: const Icon(Icons.play_arrow),
+                              tooltip: 'Test Tool',
+                              onPressed: () => _testTool(tool.name),
+                              style: IconButton.styleFrom(
+                                foregroundColor: AppColors.info,
+                                backgroundColor:
+                                    AppColors.info.withValues(alpha: 0.1),
+                              ),
+                            ),
+                      const SizedBox(width: 8),
+                    ],
+                    // Enable/Disable switch
+                    Switch(
+                      value: tool.enabled,
+                      onChanged: (value) =>
+                          _service.setToolEnabled(tool.name, value),
+                      activeColor: AppColors.success,
+                      inactiveThumbColor: AppColors.textMuted,
+                      inactiveTrackColor:
+                          AppColors.textMuted.withValues(alpha: 0.3),
+                    ),
+                  ],
+                ),
+                const SizedBox(height: 8),
+                Text(
+                  tool.description,
+                  style: TextStyle(
+                    fontSize: 13,
+                    color: AppColors.textSecondary,
+                  ),
+                ),
+                // Show last test result if available
+                if (tool.lastTestResult != null) ...[
+                  const SizedBox(height: 12),
+                  _buildTestResultBadge(tool.lastTestResult!),
+                ],
+              ],
+            ),
+          ),
+        );
+      },
+    );
+  }
+
+  Widget _buildTestResultBadge(ToolTestResult result) {
+    Color color;
+    IconData icon;
+    String label;
+
+    switch (result.status) {
+      case ToolTestStatus.success:
+        color = AppColors.success;
+        icon = Icons.check_circle;
+        label = 'Connected';
+      case ToolTestStatus.failed:
+        color = AppColors.error;
+        icon = Icons.error;
+        label = 'Failed';
+      case ToolTestStatus.timeout:
+        color = AppColors.warning;
+        icon = Icons.timer_off;
+        label = 'Timeout';
+      case ToolTestStatus.notTested:
+        color = AppColors.textMuted;
+        icon = Icons.help_outline;
+        label = 'Not Tested';
+      case ToolTestStatus.notTestable:
+        color = AppColors.textMuted;
+        icon = Icons.block;
+        label = 'Not Testable';
+    }
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(8),
+        border: Border.all(
+          color: color.withValues(alpha: 0.3),
+          width: 1,
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(icon, size: 16, color: color),
+          const SizedBox(width: 8),
+          Text(
+            label,
+            style: TextStyle(
+              fontSize: 12,
+              fontWeight: FontWeight.w500,
+              color: color,
+            ),
+          ),
+          if (result.latencyMs != null) ...[
+            const SizedBox(width: 8),
+            Text(
+              '${result.latencyMs!.toStringAsFixed(0)}ms',
+              style: TextStyle(
+                fontSize: 11,
+                color: AppColors.textMuted,
+              ),
+            ),
+          ],
+          if (result.message.isNotEmpty &&
+              result.status != ToolTestStatus.success) ...[
+            const SizedBox(width: 8),
+            Flexible(
+              child: Text(
+                result.message,
+                style: TextStyle(
+                  fontSize: 11,
+                  color: AppColors.textMuted,
+                ),
+                overflow: TextOverflow.ellipsis,
+              ),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  IconData _getCategoryIcon(ToolCategory category) {
+    switch (category) {
+      case ToolCategory.apiClient:
+        return Icons.api;
+      case ToolCategory.mcp:
+        return Icons.hub;
+      case ToolCategory.analysis:
+        return Icons.analytics;
+      case ToolCategory.orchestration:
+        return Icons.account_tree;
+      case ToolCategory.discovery:
+        return Icons.search;
+      case ToolCategory.remediation:
+        return Icons.healing;
+      case ToolCategory.gke:
+        return Icons.cloud;
+      case ToolCategory.slo:
+        return Icons.speed;
+    }
+  }
+
+  Future<void> _testTool(String toolName) async {
+    final result = await _service.testTool(toolName);
+    if (result != null && mounted) {
+      final message = result.status == ToolTestStatus.success
+          ? 'Tool $toolName is working'
+          : 'Tool $toolName test failed: ${result.message}';
+
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(message),
+          backgroundColor: result.status == ToolTestStatus.success
+              ? AppColors.success
+              : AppColors.error,
+          behavior: SnackBarBehavior.floating,
+        ),
+      );
+    }
+  }
+
+  Future<void> _testAllTools() async {
+    setState(() => _isTestingAll = true);
+
+    try {
+      final results = await _service.testAllTools();
+
+      if (mounted) {
+        final successCount =
+            results.values.where((r) => r.status == ToolTestStatus.success).length;
+        final failedCount =
+            results.values.where((r) => r.status == ToolTestStatus.failed).length;
+
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(
+              'Test completed: $successCount passed, $failedCount failed',
+            ),
+            backgroundColor:
+                failedCount == 0 ? AppColors.success : AppColors.warning,
+            behavior: SnackBarBehavior.floating,
+          ),
+        );
+      }
+    } finally {
+      if (mounted) {
+        setState(() => _isTestingAll = false);
+      }
+    }
+  }
+}

--- a/autosre/lib/services/tool_config_service.dart
+++ b/autosre/lib/services/tool_config_service.dart
@@ -1,0 +1,457 @@
+import 'dart:async';
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+/// Categories of tools based on their functionality.
+enum ToolCategory {
+  apiClient('api_client', 'API Client', 'Direct GCP API clients'),
+  mcp('mcp', 'MCP', 'Model Context Protocol tools'),
+  analysis('analysis', 'Analysis', 'Analysis and processing tools'),
+  orchestration('orchestration', 'Orchestration', 'Orchestration tools'),
+  discovery('discovery', 'Discovery', 'Discovery tools'),
+  remediation('remediation', 'Remediation', 'Remediation tools'),
+  gke('gke', 'GKE', 'GKE/Kubernetes tools'),
+  slo('slo', 'SLO', 'SLO/SLI tools');
+
+  const ToolCategory(this.value, this.displayName, this.description);
+
+  final String value;
+  final String displayName;
+  final String description;
+
+  static ToolCategory? fromValue(String value) {
+    for (final category in ToolCategory.values) {
+      if (category.value == value) {
+        return category;
+      }
+    }
+    return null;
+  }
+}
+
+/// Status of tool connectivity test.
+enum ToolTestStatus {
+  success('success'),
+  failed('failed'),
+  timeout('timeout'),
+  notTested('not_tested'),
+  notTestable('not_testable');
+
+  const ToolTestStatus(this.value);
+
+  final String value;
+
+  static ToolTestStatus fromValue(String value) {
+    for (final status in ToolTestStatus.values) {
+      if (status.value == value) {
+        return status;
+      }
+    }
+    return ToolTestStatus.notTested;
+  }
+}
+
+/// Result of a tool connectivity test.
+class ToolTestResult {
+  final ToolTestStatus status;
+  final String message;
+  final double? latencyMs;
+  final String? timestamp;
+  final Map<String, dynamic> details;
+
+  const ToolTestResult({
+    required this.status,
+    required this.message,
+    this.latencyMs,
+    this.timestamp,
+    this.details = const {},
+  });
+
+  factory ToolTestResult.fromJson(Map<String, dynamic> json) {
+    return ToolTestResult(
+      status: ToolTestStatus.fromValue(json['status'] as String? ?? 'not_tested'),
+      message: json['message'] as String? ?? '',
+      latencyMs: (json['latency_ms'] as num?)?.toDouble(),
+      timestamp: json['timestamp'] as String?,
+      details: json['details'] as Map<String, dynamic>? ?? {},
+    );
+  }
+}
+
+/// Configuration for a single tool.
+class ToolConfig {
+  final String name;
+  final String displayName;
+  final String description;
+  final ToolCategory category;
+  final bool enabled;
+  final bool testable;
+  final ToolTestResult? lastTestResult;
+
+  const ToolConfig({
+    required this.name,
+    required this.displayName,
+    required this.description,
+    required this.category,
+    required this.enabled,
+    required this.testable,
+    this.lastTestResult,
+  });
+
+  factory ToolConfig.fromJson(Map<String, dynamic> json) {
+    ToolTestResult? lastTest;
+    if (json['last_test_result'] != null) {
+      lastTest = ToolTestResult.fromJson(
+        json['last_test_result'] as Map<String, dynamic>,
+      );
+    }
+
+    return ToolConfig(
+      name: json['name'] as String,
+      displayName: json['display_name'] as String,
+      description: json['description'] as String,
+      category: ToolCategory.fromValue(json['category'] as String) ?? ToolCategory.analysis,
+      enabled: json['enabled'] as bool? ?? true,
+      testable: json['testable'] as bool? ?? false,
+      lastTestResult: lastTest,
+    );
+  }
+
+  ToolConfig copyWith({
+    String? name,
+    String? displayName,
+    String? description,
+    ToolCategory? category,
+    bool? enabled,
+    bool? testable,
+    ToolTestResult? lastTestResult,
+  }) {
+    return ToolConfig(
+      name: name ?? this.name,
+      displayName: displayName ?? this.displayName,
+      description: description ?? this.description,
+      category: category ?? this.category,
+      enabled: enabled ?? this.enabled,
+      testable: testable ?? this.testable,
+      lastTestResult: lastTestResult ?? this.lastTestResult,
+    );
+  }
+}
+
+/// Summary statistics for tool configuration.
+class ToolConfigSummary {
+  final int total;
+  final int enabled;
+  final int disabled;
+  final int testable;
+
+  const ToolConfigSummary({
+    required this.total,
+    required this.enabled,
+    required this.disabled,
+    required this.testable,
+  });
+
+  factory ToolConfigSummary.fromJson(Map<String, dynamic> json) {
+    return ToolConfigSummary(
+      total: json['total'] as int? ?? 0,
+      enabled: json['enabled'] as int? ?? 0,
+      disabled: json['disabled'] as int? ?? 0,
+      testable: json['testable'] as int? ?? 0,
+    );
+  }
+}
+
+/// Service for managing tool configuration.
+class ToolConfigService {
+  static final ToolConfigService _instance = ToolConfigService._internal();
+  factory ToolConfigService() => _instance;
+  ToolConfigService._internal();
+
+  /// Returns the API base URL based on the runtime environment.
+  String get _baseUrl {
+    if (kDebugMode) {
+      return 'http://127.0.0.1:8001';
+    }
+    return '';
+  }
+
+  final ValueNotifier<Map<ToolCategory, List<ToolConfig>>> _toolsByCategory =
+      ValueNotifier({});
+  final ValueNotifier<ToolConfigSummary?> _summary = ValueNotifier(null);
+  final ValueNotifier<bool> _isLoading = ValueNotifier(false);
+  final ValueNotifier<String?> _error = ValueNotifier(null);
+  final ValueNotifier<Set<String>> _testingTools = ValueNotifier({});
+
+  /// Tools grouped by category.
+  ValueListenable<Map<ToolCategory, List<ToolConfig>>> get toolsByCategory =>
+      _toolsByCategory;
+
+  /// Configuration summary.
+  ValueListenable<ToolConfigSummary?> get summary => _summary;
+
+  /// Whether data is currently being loaded.
+  ValueListenable<bool> get isLoading => _isLoading;
+
+  /// Error message if fetch failed.
+  ValueListenable<String?> get error => _error;
+
+  /// Set of tool names currently being tested.
+  ValueListenable<Set<String>> get testingTools => _testingTools;
+
+  /// Fetches all tool configurations from the backend.
+  Future<void> fetchConfigs() async {
+    if (_isLoading.value) return;
+
+    _isLoading.value = true;
+    _error.value = null;
+
+    try {
+      final response = await http.get(
+        Uri.parse('$_baseUrl/api/tools/config'),
+      );
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final toolsMap = data['tools'] as Map<String, dynamic>? ?? {};
+        final summaryData = data['summary'] as Map<String, dynamic>?;
+
+        // Parse tools grouped by category
+        final Map<ToolCategory, List<ToolConfig>> grouped = {};
+        for (final entry in toolsMap.entries) {
+          final category = ToolCategory.fromValue(entry.key);
+          if (category != null) {
+            final tools = (entry.value as List<dynamic>)
+                .map((t) => ToolConfig.fromJson(t as Map<String, dynamic>))
+                .toList();
+            grouped[category] = tools;
+          }
+        }
+
+        _toolsByCategory.value = grouped;
+
+        if (summaryData != null) {
+          _summary.value = ToolConfigSummary.fromJson(summaryData);
+        }
+      } else {
+        _error.value = 'Failed to fetch tool configs: ${response.statusCode}';
+      }
+    } catch (e) {
+      _error.value = 'Error fetching tool configs: $e';
+      debugPrint('ToolConfigService error: $e');
+    } finally {
+      _isLoading.value = false;
+    }
+  }
+
+  /// Updates the enabled status of a tool.
+  Future<bool> setToolEnabled(String toolName, bool enabled) async {
+    try {
+      final response = await http.put(
+        Uri.parse('$_baseUrl/api/tools/config/$toolName'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode({'enabled': enabled}),
+      );
+
+      if (response.statusCode == 200) {
+        // Update local state
+        final updatedMap = Map<ToolCategory, List<ToolConfig>>.from(
+          _toolsByCategory.value,
+        );
+
+        for (final category in updatedMap.keys) {
+          final tools = updatedMap[category]!;
+          final index = tools.indexWhere((t) => t.name == toolName);
+          if (index != -1) {
+            final updatedTools = List<ToolConfig>.from(tools);
+            updatedTools[index] = tools[index].copyWith(enabled: enabled);
+            updatedMap[category] = updatedTools;
+            break;
+          }
+        }
+
+        _toolsByCategory.value = updatedMap;
+
+        // Update summary
+        if (_summary.value != null) {
+          final currentSummary = _summary.value!;
+          _summary.value = ToolConfigSummary(
+            total: currentSummary.total,
+            enabled: enabled
+                ? currentSummary.enabled + 1
+                : currentSummary.enabled - 1,
+            disabled: enabled
+                ? currentSummary.disabled - 1
+                : currentSummary.disabled + 1,
+            testable: currentSummary.testable,
+          );
+        }
+
+        return true;
+      } else {
+        _error.value = 'Failed to update tool: ${response.statusCode}';
+        return false;
+      }
+    } catch (e) {
+      _error.value = 'Error updating tool: $e';
+      debugPrint('ToolConfigService error: $e');
+      return false;
+    }
+  }
+
+  /// Tests a specific tool's connectivity.
+  Future<ToolTestResult?> testTool(String toolName) async {
+    // Mark tool as being tested
+    _testingTools.value = {..._testingTools.value, toolName};
+
+    try {
+      final response = await http.post(
+        Uri.parse('$_baseUrl/api/tools/test/$toolName'),
+      );
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+
+        if (data['testable'] == false) {
+          return ToolTestResult(
+            status: ToolTestStatus.notTestable,
+            message: data['message'] as String? ?? 'Tool is not testable',
+          );
+        }
+
+        final resultData = data['result'] as Map<String, dynamic>?;
+        if (resultData != null) {
+          final result = ToolTestResult.fromJson(resultData);
+
+          // Update local state with test result
+          _updateToolTestResult(toolName, result);
+
+          return result;
+        }
+      }
+
+      return ToolTestResult(
+        status: ToolTestStatus.failed,
+        message: 'Failed to test tool: ${response.statusCode}',
+      );
+    } catch (e) {
+      debugPrint('ToolConfigService test error: $e');
+      return ToolTestResult(
+        status: ToolTestStatus.failed,
+        message: 'Error testing tool: $e',
+      );
+    } finally {
+      // Remove tool from testing set
+      final updated = Set<String>.from(_testingTools.value);
+      updated.remove(toolName);
+      _testingTools.value = updated;
+    }
+  }
+
+  /// Tests all testable tools.
+  Future<Map<String, ToolTestResult>> testAllTools({
+    ToolCategory? category,
+  }) async {
+    try {
+      final uri = category != null
+          ? Uri.parse('$_baseUrl/api/tools/test-all?category=${category.value}')
+          : Uri.parse('$_baseUrl/api/tools/test-all');
+
+      final response = await http.post(uri);
+
+      if (response.statusCode == 200) {
+        final data = jsonDecode(response.body) as Map<String, dynamic>;
+        final results = data['results'] as Map<String, dynamic>? ?? {};
+
+        final Map<String, ToolTestResult> parsedResults = {};
+        for (final entry in results.entries) {
+          final resultData = entry.value as Map<String, dynamic>;
+          parsedResults[entry.key] = ToolTestResult.fromJson(resultData);
+        }
+
+        // Update local state with all test results
+        for (final entry in parsedResults.entries) {
+          _updateToolTestResult(entry.key, entry.value);
+        }
+
+        return parsedResults;
+      }
+
+      return {};
+    } catch (e) {
+      debugPrint('ToolConfigService test all error: $e');
+      return {};
+    }
+  }
+
+  /// Updates the local state with a tool's test result.
+  void _updateToolTestResult(String toolName, ToolTestResult result) {
+    final updatedMap = Map<ToolCategory, List<ToolConfig>>.from(
+      _toolsByCategory.value,
+    );
+
+    for (final category in updatedMap.keys) {
+      final tools = updatedMap[category]!;
+      final index = tools.indexWhere((t) => t.name == toolName);
+      if (index != -1) {
+        final updatedTools = List<ToolConfig>.from(tools);
+        updatedTools[index] = tools[index].copyWith(lastTestResult: result);
+        updatedMap[category] = updatedTools;
+        break;
+      }
+    }
+
+    _toolsByCategory.value = updatedMap;
+  }
+
+  /// Bulk update tool configurations.
+  Future<bool> bulkUpdateTools(Map<String, bool> updates) async {
+    try {
+      final response = await http.post(
+        Uri.parse('$_baseUrl/api/tools/config/bulk'),
+        headers: {'Content-Type': 'application/json'},
+        body: jsonEncode(updates),
+      );
+
+      if (response.statusCode == 200) {
+        // Refresh configs to get updated state
+        await fetchConfigs();
+        return true;
+      }
+
+      return false;
+    } catch (e) {
+      debugPrint('ToolConfigService bulk update error: $e');
+      return false;
+    }
+  }
+
+  /// Enable all tools in a category.
+  Future<bool> enableCategory(ToolCategory category) async {
+    final tools = _toolsByCategory.value[category] ?? [];
+    final updates = <String, bool>{};
+    for (final tool in tools) {
+      updates[tool.name] = true;
+    }
+    return bulkUpdateTools(updates);
+  }
+
+  /// Disable all tools in a category.
+  Future<bool> disableCategory(ToolCategory category) async {
+    final tools = _toolsByCategory.value[category] ?? [];
+    final updates = <String, bool>{};
+    for (final tool in tools) {
+      updates[tool.name] = false;
+    }
+    return bulkUpdateTools(updates);
+  }
+
+  void dispose() {
+    _toolsByCategory.dispose();
+    _summary.dispose();
+    _isLoading.dispose();
+    _error.dispose();
+    _testingTools.dispose();
+  }
+}

--- a/sre_agent/tools/__init__.py
+++ b/sre_agent/tools/__init__.py
@@ -129,6 +129,16 @@ from .mcp.gcp import (
 # Reporting Tools
 from .reporting import synthesize_report
 
+# Configuration
+from .config import (
+    ToolCategory,
+    ToolConfig,
+    ToolConfigManager,
+    ToolTestResult,
+    ToolTestStatus,
+    get_tool_config_manager,
+)
+
 __all__ = [
     "analyze_aggregate_metrics",
     "analyze_bigquery_log_patterns",
@@ -203,4 +213,11 @@ __all__ = [
     "summarize_trace",
     "synthesize_report",
     "validate_trace_quality",
+    # Configuration
+    "ToolCategory",
+    "ToolConfig",
+    "ToolConfigManager",
+    "ToolTestResult",
+    "ToolTestStatus",
+    "get_tool_config_manager",
 ]

--- a/sre_agent/tools/config.py
+++ b/sre_agent/tools/config.py
@@ -1,0 +1,870 @@
+"""Tool Configuration Management for SRE Agent.
+
+This module provides the ability to enable/disable tools and test their connectivity.
+Configuration is stored in memory with persistence via a JSON file.
+"""
+
+import asyncio
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable, Coroutine
+
+logger = logging.getLogger(__name__)
+
+# Configuration file path (can be overridden via environment variable)
+CONFIG_FILE_PATH = Path(os.getenv("TOOL_CONFIG_PATH", ".tool_config.json"))
+
+
+class ToolCategory(str, Enum):
+    """Categories of tools based on their functionality."""
+
+    API_CLIENT = "api_client"       # Direct GCP API clients (Trace, Logging, Monitoring, etc.)
+    MCP = "mcp"                     # Model Context Protocol tools (BigQuery, Logging, Monitoring MCP)
+    ANALYSIS = "analysis"           # Analysis/processing tools (patterns, anomalies, correlation)
+    ORCHESTRATION = "orchestration" # Orchestration tools (run_aggregate_analysis, run_triage_analysis)
+    DISCOVERY = "discovery"         # Discovery tools
+    REMEDIATION = "remediation"     # Remediation tools
+    GKE = "gke"                     # GKE/Kubernetes tools
+    SLO = "slo"                     # SLO/SLI tools
+
+
+class ToolTestStatus(str, Enum):
+    """Status of tool connectivity test."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    TIMEOUT = "timeout"
+    NOT_TESTED = "not_tested"
+    NOT_TESTABLE = "not_testable"
+
+
+@dataclass
+class ToolTestResult:
+    """Result of a tool connectivity test."""
+
+    status: ToolTestStatus
+    message: str
+    latency_ms: float | None = None
+    timestamp: str = field(default_factory=lambda: datetime.utcnow().isoformat())
+    details: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class ToolConfig:
+    """Configuration for a single tool."""
+
+    name: str
+    display_name: str
+    description: str
+    category: ToolCategory
+    enabled: bool = True
+    testable: bool = False  # Whether the tool can be tested for connectivity
+    last_test_result: ToolTestResult | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON serialization."""
+        return {
+            "name": self.name,
+            "display_name": self.display_name,
+            "description": self.description,
+            "category": self.category.value,
+            "enabled": self.enabled,
+            "testable": self.testable,
+            "last_test_result": {
+                "status": self.last_test_result.status.value,
+                "message": self.last_test_result.message,
+                "latency_ms": self.last_test_result.latency_ms,
+                "timestamp": self.last_test_result.timestamp,
+                "details": self.last_test_result.details,
+            } if self.last_test_result else None,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "ToolConfig":
+        """Create from dictionary."""
+        last_test = None
+        if data.get("last_test_result"):
+            test_data = data["last_test_result"]
+            last_test = ToolTestResult(
+                status=ToolTestStatus(test_data["status"]),
+                message=test_data["message"],
+                latency_ms=test_data.get("latency_ms"),
+                timestamp=test_data.get("timestamp", ""),
+                details=test_data.get("details", {}),
+            )
+
+        return cls(
+            name=data["name"],
+            display_name=data["display_name"],
+            description=data["description"],
+            category=ToolCategory(data["category"]),
+            enabled=data.get("enabled", True),
+            testable=data.get("testable", False),
+            last_test_result=last_test,
+        )
+
+
+# ============================================================================
+# Tool Registry - Define all available tools
+# ============================================================================
+
+# Tool definitions with metadata
+TOOL_DEFINITIONS: list[ToolConfig] = [
+    # -------------------------------------------------------------------------
+    # API Client Tools (Direct GCP APIs) - TESTABLE
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="fetch_trace",
+        display_name="Fetch Trace",
+        description="Fetch a trace from Cloud Trace API",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="list_traces",
+        display_name="List Traces",
+        description="List traces from Cloud Trace API",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="find_example_traces",
+        display_name="Find Example Traces",
+        description="Find example traces for comparison",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="get_trace_by_url",
+        display_name="Get Trace by URL",
+        description="Fetch a trace using its Cloud Console URL",
+        category=ToolCategory.API_CLIENT,
+        testable=False,
+    ),
+    ToolConfig(
+        name="list_log_entries",
+        display_name="List Log Entries",
+        description="List log entries from Cloud Logging API",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="get_logs_for_trace",
+        display_name="Get Logs for Trace",
+        description="Get log entries correlated with a specific trace",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="list_error_events",
+        display_name="List Error Events",
+        description="List error events from Cloud Logging",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="list_time_series",
+        display_name="List Time Series",
+        description="List metrics time series from Cloud Monitoring",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="query_promql",
+        display_name="Query PromQL",
+        description="Execute PromQL queries against Cloud Monitoring",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="list_alerts",
+        display_name="List Alerts",
+        description="List active alerts from Cloud Monitoring",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="get_alert",
+        display_name="Get Alert",
+        description="Get details of a specific alert",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="list_alert_policies",
+        display_name="List Alert Policies",
+        description="List alert policies from Cloud Monitoring",
+        category=ToolCategory.API_CLIENT,
+        testable=True,
+    ),
+    ToolConfig(
+        name="get_current_time",
+        display_name="Get Current Time",
+        description="Get current time in various formats",
+        category=ToolCategory.API_CLIENT,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # MCP Tools - TESTABLE
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="mcp_list_log_entries",
+        display_name="MCP List Log Entries",
+        description="List log entries via MCP Cloud Logging server",
+        category=ToolCategory.MCP,
+        testable=True,
+    ),
+    ToolConfig(
+        name="mcp_list_timeseries",
+        display_name="MCP List Time Series",
+        description="List metrics via MCP Cloud Monitoring server",
+        category=ToolCategory.MCP,
+        testable=True,
+    ),
+    ToolConfig(
+        name="mcp_query_range",
+        display_name="MCP Query Range (PromQL)",
+        description="Execute PromQL queries via MCP Cloud Monitoring server",
+        category=ToolCategory.MCP,
+        testable=True,
+    ),
+
+    # -------------------------------------------------------------------------
+    # BigQuery/OTel Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="analyze_aggregate_metrics",
+        display_name="Analyze Aggregate Metrics",
+        description="Analyze aggregate metrics from BigQuery OpenTelemetry tables",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="find_exemplar_traces",
+        display_name="Find Exemplar Traces",
+        description="Find exemplar traces (baseline and anomaly) from BigQuery",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="compare_time_periods",
+        display_name="Compare Time Periods",
+        description="Compare metrics between two time periods",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="detect_trend_changes",
+        display_name="Detect Trend Changes",
+        description="Detect trend changes in metrics over time",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="correlate_logs_with_trace",
+        display_name="Correlate Logs with Trace",
+        description="Correlate log entries with a specific trace",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Trace Analysis Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="calculate_span_durations",
+        display_name="Calculate Span Durations",
+        description="Calculate durations for all spans in a trace",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="extract_errors",
+        display_name="Extract Errors",
+        description="Extract error information from trace spans",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="build_call_graph",
+        display_name="Build Call Graph",
+        description="Build a call graph from trace data",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="summarize_trace",
+        display_name="Summarize Trace",
+        description="Generate a summary of trace data",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="validate_trace_quality",
+        display_name="Validate Trace Quality",
+        description="Validate the quality and completeness of trace data",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="compare_span_timings",
+        display_name="Compare Span Timings",
+        description="Compare span timings between two traces",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="find_structural_differences",
+        display_name="Find Structural Differences",
+        description="Find structural differences between two traces",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Log Analysis Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="extract_log_patterns",
+        display_name="Extract Log Patterns",
+        description="Extract patterns from log entries using Drain3",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="compare_log_patterns",
+        display_name="Compare Log Patterns",
+        description="Compare log patterns between two time periods",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="analyze_log_anomalies",
+        display_name="Analyze Log Anomalies",
+        description="Analyze log anomalies and detect issues",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Metrics Analysis Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="detect_metric_anomalies",
+        display_name="Detect Metric Anomalies",
+        description="Detect anomalies in metric time series",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="compare_metric_windows",
+        display_name="Compare Metric Windows",
+        description="Compare metrics between two time windows",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="calculate_series_stats",
+        display_name="Calculate Series Stats",
+        description="Calculate statistical metrics for time series",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Cross-Signal Correlation Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="correlate_trace_with_metrics",
+        display_name="Correlate Trace with Metrics",
+        description="Correlate trace data with metrics",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="correlate_metrics_with_traces_via_exemplars",
+        display_name="Correlate Metrics via Exemplars",
+        description="Correlate metrics with traces using exemplars",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="build_cross_signal_timeline",
+        display_name="Build Cross-Signal Timeline",
+        description="Build a unified timeline from multiple signal sources",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="analyze_signal_correlation_strength",
+        display_name="Analyze Signal Correlation",
+        description="Analyze the correlation strength between signals",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Critical Path & Dependency Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="analyze_critical_path",
+        display_name="Analyze Critical Path",
+        description="Analyze the critical path in a trace",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="find_bottleneck_services",
+        display_name="Find Bottleneck Services",
+        description="Find services that are bottlenecks in the request path",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="calculate_critical_path_contribution",
+        display_name="Calculate Critical Path Contribution",
+        description="Calculate each service's contribution to critical path",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="build_service_dependency_graph",
+        display_name="Build Service Dependency Graph",
+        description="Build a graph of service dependencies",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="analyze_upstream_downstream_impact",
+        display_name="Analyze Impact",
+        description="Analyze upstream and downstream service impact",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="detect_circular_dependencies",
+        display_name="Detect Circular Dependencies",
+        description="Detect circular dependencies in service graph",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+    ToolConfig(
+        name="find_hidden_dependencies",
+        display_name="Find Hidden Dependencies",
+        description="Find hidden or implicit service dependencies",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # SLO/SLI Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="list_slos",
+        display_name="List SLOs",
+        description="List Service Level Objectives",
+        category=ToolCategory.SLO,
+        testable=True,
+    ),
+    ToolConfig(
+        name="get_slo_status",
+        display_name="Get SLO Status",
+        description="Get current status of an SLO",
+        category=ToolCategory.SLO,
+        testable=True,
+    ),
+    ToolConfig(
+        name="analyze_error_budget_burn",
+        display_name="Analyze Error Budget Burn",
+        description="Analyze error budget burn rate",
+        category=ToolCategory.SLO,
+        testable=False,
+    ),
+    ToolConfig(
+        name="get_golden_signals",
+        display_name="Get Golden Signals",
+        description="Get SRE golden signals for a service",
+        category=ToolCategory.SLO,
+        testable=False,
+    ),
+    ToolConfig(
+        name="correlate_incident_with_slo_impact",
+        display_name="Correlate Incident with SLO",
+        description="Correlate an incident with SLO impact",
+        category=ToolCategory.SLO,
+        testable=False,
+    ),
+    ToolConfig(
+        name="predict_slo_violation",
+        display_name="Predict SLO Violation",
+        description="Predict potential SLO violations",
+        category=ToolCategory.SLO,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # GKE/Kubernetes Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="get_gke_cluster_health",
+        display_name="Get GKE Cluster Health",
+        description="Get health status of a GKE cluster",
+        category=ToolCategory.GKE,
+        testable=True,
+    ),
+    ToolConfig(
+        name="analyze_node_conditions",
+        display_name="Analyze Node Conditions",
+        description="Analyze GKE node conditions",
+        category=ToolCategory.GKE,
+        testable=True,
+    ),
+    ToolConfig(
+        name="get_pod_restart_events",
+        display_name="Get Pod Restart Events",
+        description="Get pod restart events from GKE",
+        category=ToolCategory.GKE,
+        testable=True,
+    ),
+    ToolConfig(
+        name="analyze_hpa_events",
+        display_name="Analyze HPA Events",
+        description="Analyze Horizontal Pod Autoscaler events",
+        category=ToolCategory.GKE,
+        testable=True,
+    ),
+    ToolConfig(
+        name="get_container_oom_events",
+        display_name="Get Container OOM Events",
+        description="Get container Out-of-Memory events",
+        category=ToolCategory.GKE,
+        testable=True,
+    ),
+    ToolConfig(
+        name="correlate_trace_with_kubernetes",
+        display_name="Correlate Trace with K8s",
+        description="Correlate trace data with Kubernetes events",
+        category=ToolCategory.GKE,
+        testable=False,
+    ),
+    ToolConfig(
+        name="get_workload_health_summary",
+        display_name="Get Workload Health",
+        description="Get health summary of GKE workloads",
+        category=ToolCategory.GKE,
+        testable=True,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Remediation Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="generate_remediation_suggestions",
+        display_name="Generate Remediation Suggestions",
+        description="Generate remediation suggestions for issues",
+        category=ToolCategory.REMEDIATION,
+        testable=False,
+    ),
+    ToolConfig(
+        name="get_gcloud_commands",
+        display_name="Get gcloud Commands",
+        description="Get gcloud commands for remediation",
+        category=ToolCategory.REMEDIATION,
+        testable=False,
+    ),
+    ToolConfig(
+        name="estimate_remediation_risk",
+        display_name="Estimate Remediation Risk",
+        description="Estimate the risk of remediation actions",
+        category=ToolCategory.REMEDIATION,
+        testable=False,
+    ),
+    ToolConfig(
+        name="find_similar_past_incidents",
+        display_name="Find Similar Incidents",
+        description="Find similar past incidents",
+        category=ToolCategory.REMEDIATION,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Discovery Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="discover_telemetry_sources",
+        display_name="Discover Telemetry Sources",
+        description="Discover available telemetry sources",
+        category=ToolCategory.DISCOVERY,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Orchestration Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="run_aggregate_analysis",
+        display_name="Run Aggregate Analysis",
+        description="Run Stage 0: Aggregate analysis using BigQuery",
+        category=ToolCategory.ORCHESTRATION,
+        testable=False,
+    ),
+    ToolConfig(
+        name="run_triage_analysis",
+        display_name="Run Triage Analysis",
+        description="Run Stage 1: Parallel triage analysis with sub-agents",
+        category=ToolCategory.ORCHESTRATION,
+        testable=False,
+    ),
+    ToolConfig(
+        name="run_log_pattern_analysis",
+        display_name="Run Log Pattern Analysis",
+        description="Run log pattern analysis to find emergent issues",
+        category=ToolCategory.ORCHESTRATION,
+        testable=False,
+    ),
+    ToolConfig(
+        name="run_deep_dive_analysis",
+        display_name="Run Deep Dive Analysis",
+        description="Run Stage 2: Deep dive root cause analysis",
+        category=ToolCategory.ORCHESTRATION,
+        testable=False,
+    ),
+
+    # -------------------------------------------------------------------------
+    # Reporting Tools
+    # -------------------------------------------------------------------------
+    ToolConfig(
+        name="synthesize_report",
+        display_name="Synthesize Report",
+        description="Synthesize a comprehensive incident report",
+        category=ToolCategory.ANALYSIS,
+        testable=False,
+    ),
+]
+
+
+class ToolConfigManager:
+    """Manager for tool configuration with persistence."""
+
+    _instance: "ToolConfigManager | None" = None
+
+    def __new__(cls) -> "ToolConfigManager":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._instance._initialized = False
+        return cls._instance
+
+    def __init__(self) -> None:
+        if self._initialized:
+            return
+
+        self._configs: dict[str, ToolConfig] = {}
+        self._test_functions: dict[str, Callable[[], Coroutine[Any, Any, ToolTestResult]]] = {}
+        self._initialized = True
+
+        # Initialize with default configs
+        self._initialize_defaults()
+
+        # Load persisted config
+        self._load_config()
+
+    def _initialize_defaults(self) -> None:
+        """Initialize with default tool configurations."""
+        for tool_def in TOOL_DEFINITIONS:
+            self._configs[tool_def.name] = ToolConfig(
+                name=tool_def.name,
+                display_name=tool_def.display_name,
+                description=tool_def.description,
+                category=tool_def.category,
+                enabled=tool_def.enabled,
+                testable=tool_def.testable,
+            )
+
+    def _load_config(self) -> None:
+        """Load configuration from file if exists."""
+        if not CONFIG_FILE_PATH.exists():
+            return
+
+        try:
+            with open(CONFIG_FILE_PATH) as f:
+                data = json.load(f)
+
+            for tool_data in data.get("tools", []):
+                name = tool_data.get("name")
+                if name and name in self._configs:
+                    # Only update enabled status from persisted config
+                    self._configs[name].enabled = tool_data.get("enabled", True)
+
+                    # Restore last test result if present
+                    if tool_data.get("last_test_result"):
+                        test_data = tool_data["last_test_result"]
+                        self._configs[name].last_test_result = ToolTestResult(
+                            status=ToolTestStatus(test_data["status"]),
+                            message=test_data["message"],
+                            latency_ms=test_data.get("latency_ms"),
+                            timestamp=test_data.get("timestamp", ""),
+                            details=test_data.get("details", {}),
+                        )
+
+            logger.info(f"Loaded tool configuration from {CONFIG_FILE_PATH}")
+        except Exception as e:
+            logger.warning(f"Failed to load tool configuration: {e}")
+
+    def _save_config(self) -> None:
+        """Save configuration to file."""
+        try:
+            data = {
+                "tools": [config.to_dict() for config in self._configs.values()],
+                "version": "1.0",
+                "updated_at": datetime.utcnow().isoformat(),
+            }
+
+            with open(CONFIG_FILE_PATH, "w") as f:
+                json.dump(data, f, indent=2)
+
+            logger.debug(f"Saved tool configuration to {CONFIG_FILE_PATH}")
+        except Exception as e:
+            logger.error(f"Failed to save tool configuration: {e}")
+
+    def get_all_configs(self) -> list[ToolConfig]:
+        """Get all tool configurations."""
+        return list(self._configs.values())
+
+    def get_config(self, tool_name: str) -> ToolConfig | None:
+        """Get configuration for a specific tool."""
+        return self._configs.get(tool_name)
+
+    def get_configs_by_category(self, category: ToolCategory) -> list[ToolConfig]:
+        """Get all tool configurations in a category."""
+        return [c for c in self._configs.values() if c.category == category]
+
+    def set_enabled(self, tool_name: str, enabled: bool) -> bool:
+        """Enable or disable a tool. Returns True if successful."""
+        if tool_name not in self._configs:
+            return False
+
+        self._configs[tool_name].enabled = enabled
+        self._save_config()
+        logger.info(f"Tool '{tool_name}' {'enabled' if enabled else 'disabled'}")
+        return True
+
+    def is_enabled(self, tool_name: str) -> bool:
+        """Check if a tool is enabled."""
+        config = self._configs.get(tool_name)
+        return config.enabled if config else False
+
+    def get_enabled_tools(self) -> list[str]:
+        """Get list of enabled tool names."""
+        return [name for name, config in self._configs.items() if config.enabled]
+
+    def get_disabled_tools(self) -> list[str]:
+        """Get list of disabled tool names."""
+        return [name for name, config in self._configs.items() if not config.enabled]
+
+    def register_test_function(
+        self,
+        tool_name: str,
+        test_fn: Callable[[], Coroutine[Any, Any, ToolTestResult]]
+    ) -> None:
+        """Register a test function for a tool."""
+        self._test_functions[tool_name] = test_fn
+
+    async def test_tool(self, tool_name: str) -> ToolTestResult:
+        """Test a tool's connectivity/functionality."""
+        config = self._configs.get(tool_name)
+
+        if not config:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message=f"Tool '{tool_name}' not found",
+            )
+
+        if not config.testable:
+            return ToolTestResult(
+                status=ToolTestStatus.NOT_TESTABLE,
+                message=f"Tool '{tool_name}' is not testable",
+            )
+
+        test_fn = self._test_functions.get(tool_name)
+
+        if not test_fn:
+            return ToolTestResult(
+                status=ToolTestStatus.NOT_TESTABLE,
+                message=f"No test function registered for '{tool_name}'",
+            )
+
+        try:
+            start_time = asyncio.get_event_loop().time()
+            result = await asyncio.wait_for(test_fn(), timeout=30.0)
+            latency = (asyncio.get_event_loop().time() - start_time) * 1000
+            result.latency_ms = latency
+
+            # Store result
+            config.last_test_result = result
+            self._save_config()
+
+            return result
+        except asyncio.TimeoutError:
+            result = ToolTestResult(
+                status=ToolTestStatus.TIMEOUT,
+                message=f"Tool test timed out after 30 seconds",
+            )
+            config.last_test_result = result
+            self._save_config()
+            return result
+        except Exception as e:
+            logger.error(f"Error testing tool '{tool_name}': {e}", exc_info=True)
+            result = ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message=str(e),
+            )
+            config.last_test_result = result
+            self._save_config()
+            return result
+
+    async def test_all_testable_tools(self) -> dict[str, ToolTestResult]:
+        """Test all testable tools and return results."""
+        results: dict[str, ToolTestResult] = {}
+
+        testable_tools = [
+            name for name, config in self._configs.items()
+            if config.testable and name in self._test_functions
+        ]
+
+        # Run tests in parallel with a semaphore to limit concurrency
+        semaphore = asyncio.Semaphore(5)
+
+        async def test_with_semaphore(name: str) -> tuple[str, ToolTestResult]:
+            async with semaphore:
+                result = await self.test_tool(name)
+                return name, result
+
+        tasks = [test_with_semaphore(name) for name in testable_tools]
+        test_results = await asyncio.gather(*tasks, return_exceptions=True)
+
+        for item in test_results:
+            if isinstance(item, tuple):
+                name, result = item
+                results[name] = result
+            elif isinstance(item, Exception):
+                logger.error(f"Error in batch test: {item}")
+
+        return results
+
+
+# Create singleton instance
+_tool_config_manager: ToolConfigManager | None = None
+
+
+def get_tool_config_manager() -> ToolConfigManager:
+    """Get the singleton ToolConfigManager instance."""
+    global _tool_config_manager
+    if _tool_config_manager is None:
+        _tool_config_manager = ToolConfigManager()
+    return _tool_config_manager

--- a/sre_agent/tools/test_functions.py
+++ b/sre_agent/tools/test_functions.py
@@ -1,0 +1,401 @@
+"""Test functions for verifying tool connectivity.
+
+This module registers test functions for tools that can be tested for connectivity.
+These tests perform minimal API calls to verify the tool is working.
+"""
+
+import logging
+import os
+from typing import Any
+
+from .config import ToolTestResult, ToolTestStatus, get_tool_config_manager
+
+logger = logging.getLogger(__name__)
+
+
+def get_test_project_id() -> str | None:
+    """Get project ID for testing from environment."""
+    return (
+        os.getenv("TEST_PROJECT_ID")
+        or os.getenv("GOOGLE_CLOUD_PROJECT")
+        or os.getenv("GCP_PROJECT_ID")
+    )
+
+
+# ============================================================================
+# API Client Test Functions
+# ============================================================================
+
+
+async def test_fetch_trace() -> ToolTestResult:
+    """Test Cloud Trace API connectivity."""
+    try:
+        from .clients.factory import get_trace_client
+
+        client = get_trace_client()
+        project_id = get_test_project_id()
+
+        if not project_id:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="No project ID configured. Set GOOGLE_CLOUD_PROJECT environment variable.",
+            )
+
+        # Just verify we can create the client and it has the expected methods
+        # We don't actually call list_traces as it might be slow with large projects
+        if hasattr(client, "list_traces") and hasattr(client, "get_trace"):
+            return ToolTestResult(
+                status=ToolTestStatus.SUCCESS,
+                message="Cloud Trace API client initialized successfully",
+                details={"project_id": project_id},
+            )
+        else:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="Cloud Trace API client missing expected methods",
+            )
+    except Exception as e:
+        return ToolTestResult(
+            status=ToolTestStatus.FAILED,
+            message=f"Failed to initialize Cloud Trace client: {e}",
+        )
+
+
+async def test_list_traces() -> ToolTestResult:
+    """Test list_traces functionality."""
+    return await test_fetch_trace()  # Same underlying client
+
+
+async def test_find_example_traces() -> ToolTestResult:
+    """Test find_example_traces functionality."""
+    return await test_fetch_trace()  # Same underlying client
+
+
+async def test_list_log_entries() -> ToolTestResult:
+    """Test Cloud Logging API connectivity."""
+    try:
+        from .clients.factory import get_logging_client
+
+        client = get_logging_client()
+        project_id = get_test_project_id()
+
+        if not project_id:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="No project ID configured. Set GOOGLE_CLOUD_PROJECT environment variable.",
+            )
+
+        if hasattr(client, "list_log_entries"):
+            return ToolTestResult(
+                status=ToolTestStatus.SUCCESS,
+                message="Cloud Logging API client initialized successfully",
+                details={"project_id": project_id},
+            )
+        else:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="Cloud Logging API client missing expected methods",
+            )
+    except Exception as e:
+        return ToolTestResult(
+            status=ToolTestStatus.FAILED,
+            message=f"Failed to initialize Cloud Logging client: {e}",
+        )
+
+
+async def test_get_logs_for_trace() -> ToolTestResult:
+    """Test get_logs_for_trace functionality."""
+    return await test_list_log_entries()  # Same underlying client
+
+
+async def test_list_error_events() -> ToolTestResult:
+    """Test list_error_events functionality."""
+    return await test_list_log_entries()  # Same underlying client
+
+
+async def test_list_time_series() -> ToolTestResult:
+    """Test Cloud Monitoring API connectivity."""
+    try:
+        from .clients.factory import get_monitoring_client
+
+        client = get_monitoring_client()
+        project_id = get_test_project_id()
+
+        if not project_id:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="No project ID configured. Set GOOGLE_CLOUD_PROJECT environment variable.",
+            )
+
+        if hasattr(client, "list_time_series"):
+            return ToolTestResult(
+                status=ToolTestStatus.SUCCESS,
+                message="Cloud Monitoring API client initialized successfully",
+                details={"project_id": project_id},
+            )
+        else:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="Cloud Monitoring API client missing expected methods",
+            )
+    except Exception as e:
+        return ToolTestResult(
+            status=ToolTestStatus.FAILED,
+            message=f"Failed to initialize Cloud Monitoring client: {e}",
+        )
+
+
+async def test_query_promql() -> ToolTestResult:
+    """Test PromQL query functionality."""
+    return await test_list_time_series()  # Same underlying client
+
+
+async def test_list_alerts() -> ToolTestResult:
+    """Test alerts API connectivity."""
+    try:
+        from .clients.factory import get_alert_policy_client
+
+        client = get_alert_policy_client()
+        project_id = get_test_project_id()
+
+        if not project_id:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="No project ID configured. Set GOOGLE_CLOUD_PROJECT environment variable.",
+            )
+
+        if hasattr(client, "list_alert_policies"):
+            return ToolTestResult(
+                status=ToolTestStatus.SUCCESS,
+                message="Alert Policy API client initialized successfully",
+                details={"project_id": project_id},
+            )
+        else:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="Alert Policy API client missing expected methods",
+            )
+    except Exception as e:
+        return ToolTestResult(
+            status=ToolTestStatus.FAILED,
+            message=f"Failed to initialize Alert Policy client: {e}",
+        )
+
+
+async def test_get_alert() -> ToolTestResult:
+    """Test get_alert functionality."""
+    return await test_list_alerts()  # Same underlying client
+
+
+async def test_list_alert_policies() -> ToolTestResult:
+    """Test list_alert_policies functionality."""
+    return await test_list_alerts()  # Same underlying client
+
+
+# ============================================================================
+# MCP Test Functions
+# ============================================================================
+
+
+async def test_mcp_list_log_entries() -> ToolTestResult:
+    """Test MCP Cloud Logging server connectivity."""
+    try:
+        from .mcp.gcp import create_logging_mcp_toolset
+
+        toolset = create_logging_mcp_toolset()
+
+        if toolset is None:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="Failed to create MCP Logging toolset - returned None",
+            )
+
+        return ToolTestResult(
+            status=ToolTestStatus.SUCCESS,
+            message="MCP Logging toolset created successfully",
+            details={"toolset_type": str(type(toolset).__name__)},
+        )
+    except Exception as e:
+        return ToolTestResult(
+            status=ToolTestStatus.FAILED,
+            message=f"Failed to create MCP Logging toolset: {e}",
+        )
+
+
+async def test_mcp_list_timeseries() -> ToolTestResult:
+    """Test MCP Cloud Monitoring server connectivity."""
+    try:
+        from .mcp.gcp import create_monitoring_mcp_toolset
+
+        toolset = create_monitoring_mcp_toolset()
+
+        if toolset is None:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="Failed to create MCP Monitoring toolset - returned None",
+            )
+
+        return ToolTestResult(
+            status=ToolTestStatus.SUCCESS,
+            message="MCP Monitoring toolset created successfully",
+            details={"toolset_type": str(type(toolset).__name__)},
+        )
+    except Exception as e:
+        return ToolTestResult(
+            status=ToolTestStatus.FAILED,
+            message=f"Failed to create MCP Monitoring toolset: {e}",
+        )
+
+
+async def test_mcp_query_range() -> ToolTestResult:
+    """Test MCP PromQL query functionality."""
+    return await test_mcp_list_timeseries()  # Same underlying MCP server
+
+
+# ============================================================================
+# SLO Test Functions
+# ============================================================================
+
+
+async def test_list_slos() -> ToolTestResult:
+    """Test SLO API connectivity."""
+    try:
+        from google.cloud import monitoring_v3
+
+        client = monitoring_v3.ServiceMonitoringServiceClient()
+        project_id = get_test_project_id()
+
+        if not project_id:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="No project ID configured. Set GOOGLE_CLOUD_PROJECT environment variable.",
+            )
+
+        if hasattr(client, "list_services") and hasattr(client, "list_service_level_objectives"):
+            return ToolTestResult(
+                status=ToolTestStatus.SUCCESS,
+                message="Service Monitoring API client initialized successfully",
+                details={"project_id": project_id},
+            )
+        else:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="Service Monitoring API client missing expected methods",
+            )
+    except Exception as e:
+        return ToolTestResult(
+            status=ToolTestStatus.FAILED,
+            message=f"Failed to initialize Service Monitoring client: {e}",
+        )
+
+
+async def test_get_slo_status() -> ToolTestResult:
+    """Test get_slo_status functionality."""
+    return await test_list_slos()  # Same underlying client
+
+
+# ============================================================================
+# GKE Test Functions
+# ============================================================================
+
+
+async def test_get_gke_cluster_health() -> ToolTestResult:
+    """Test GKE API connectivity."""
+    try:
+        from google.cloud import container_v1
+
+        client = container_v1.ClusterManagerClient()
+        project_id = get_test_project_id()
+
+        if not project_id:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="No project ID configured. Set GOOGLE_CLOUD_PROJECT environment variable.",
+            )
+
+        if hasattr(client, "list_clusters") and hasattr(client, "get_cluster"):
+            return ToolTestResult(
+                status=ToolTestStatus.SUCCESS,
+                message="GKE Cluster Manager API client initialized successfully",
+                details={"project_id": project_id},
+            )
+        else:
+            return ToolTestResult(
+                status=ToolTestStatus.FAILED,
+                message="GKE Cluster Manager API client missing expected methods",
+            )
+    except Exception as e:
+        return ToolTestResult(
+            status=ToolTestStatus.FAILED,
+            message=f"Failed to initialize GKE Cluster Manager client: {e}",
+        )
+
+
+async def test_analyze_node_conditions() -> ToolTestResult:
+    """Test analyze_node_conditions functionality."""
+    return await test_get_gke_cluster_health()  # Same underlying approach
+
+
+async def test_get_pod_restart_events() -> ToolTestResult:
+    """Test get_pod_restart_events functionality."""
+    # This uses Cloud Logging, so test that
+    return await test_list_log_entries()
+
+
+async def test_analyze_hpa_events() -> ToolTestResult:
+    """Test analyze_hpa_events functionality."""
+    # This uses Cloud Logging, so test that
+    return await test_list_log_entries()
+
+
+async def test_get_container_oom_events() -> ToolTestResult:
+    """Test get_container_oom_events functionality."""
+    # This uses Cloud Logging, so test that
+    return await test_list_log_entries()
+
+
+async def test_get_workload_health_summary() -> ToolTestResult:
+    """Test get_workload_health_summary functionality."""
+    return await test_get_gke_cluster_health()
+
+
+# ============================================================================
+# Registration Function
+# ============================================================================
+
+
+def register_all_test_functions() -> None:
+    """Register all test functions with the ToolConfigManager."""
+    manager = get_tool_config_manager()
+
+    # API Client tests
+    manager.register_test_function("fetch_trace", test_fetch_trace)
+    manager.register_test_function("list_traces", test_list_traces)
+    manager.register_test_function("find_example_traces", test_find_example_traces)
+    manager.register_test_function("list_log_entries", test_list_log_entries)
+    manager.register_test_function("get_logs_for_trace", test_get_logs_for_trace)
+    manager.register_test_function("list_error_events", test_list_error_events)
+    manager.register_test_function("list_time_series", test_list_time_series)
+    manager.register_test_function("query_promql", test_query_promql)
+    manager.register_test_function("list_alerts", test_list_alerts)
+    manager.register_test_function("get_alert", test_get_alert)
+    manager.register_test_function("list_alert_policies", test_list_alert_policies)
+
+    # MCP tests
+    manager.register_test_function("mcp_list_log_entries", test_mcp_list_log_entries)
+    manager.register_test_function("mcp_list_timeseries", test_mcp_list_timeseries)
+    manager.register_test_function("mcp_query_range", test_mcp_query_range)
+
+    # SLO tests
+    manager.register_test_function("list_slos", test_list_slos)
+    manager.register_test_function("get_slo_status", test_get_slo_status)
+
+    # GKE tests
+    manager.register_test_function("get_gke_cluster_health", test_get_gke_cluster_health)
+    manager.register_test_function("analyze_node_conditions", test_analyze_node_conditions)
+    manager.register_test_function("get_pod_restart_events", test_get_pod_restart_events)
+    manager.register_test_function("analyze_hpa_events", test_analyze_hpa_events)
+    manager.register_test_function("get_container_oom_events", test_get_container_oom_events)
+    manager.register_test_function("get_workload_health_summary", test_get_workload_health_summary)
+
+    logger.info("Registered all tool test functions")


### PR DESCRIPTION
…ty testing

This feature allows users to configure which tools the SRE agent can use:

Backend:
- Add tool configuration models and persistent storage (config.py)
- Define all 55+ tools with categories: API Client, MCP, Analysis, Orchestration, Discovery, Remediation, GKE, and SLO
- Add test functions for verifying tool connectivity (test_functions.py)
- Add API endpoints for tool configuration CRUD:
  - GET /api/tools/config - List all tools with config
  - GET /api/tools/config/{tool_name} - Get specific tool config
  - PUT /api/tools/config/{tool_name} - Enable/disable a tool
  - POST /api/tools/config/bulk - Bulk update multiple tools
  - POST /api/tools/test/{tool_name} - Test tool connectivity
  - POST /api/tools/test-all - Test all testable tools
- Integrate tool configuration with agent tool selection
- Support for testable tools: API clients, MCP servers, GKE, SLO

Frontend (Flutter):
- Add ToolConfigService for managing tool configuration state
- Add ToolConfigPage with tabbed UI organized by category
- Display summary stats (total, enabled, disabled, testable)
- Enable/disable toggle for each tool
- Test button for testable tools with latency display
- Category-level bulk enable/disable actions
- Test all testable tools with summary results
- Navigation from main page via tool icon in app bar