### PR TITLE
fix: resolve tool call loops by using unique call IDs instead of tool…

### DIFF
--- a/tests/test_genui_chat_events.py
+++ b/tests/test_genui_chat_events.py
@@ -1,117 +1,277 @@
+"""Tests for GenUI chat endpoint tool call events.
+
+These tests verify that:
+1. Request validation works correctly (Fix #3)
+2. The shared tool event helper functions work correctly
+"""
+
 import json
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
+import httpx
 import pytest
-from fastapi.testclient import TestClient
+import pytest_asyncio
 
-# We need to import the app from server.py
-# Since server.py is in the root, we might need to add it to path or import nicely.
-# Assuming we can import it if we are running from root.
-from server import app
+from server import (
+    TOOL_WIDGET_MAP,
+    _create_tool_call_events,
+    _create_tool_response_events,
+    _normalize_tool_args,
+    app,
+)
 
-client = TestClient(app)
+
+@pytest_asyncio.fixture
+async def async_client():
+    """Create an async HTTP client for testing streaming endpoints."""
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        yield client
+
+
+# --- Unit Tests for Shared Helper Functions (Fix #2) ---
+
+
+def test_normalize_tool_args_none():
+    """Test _normalize_tool_args with None."""
+    result = _normalize_tool_args(None)
+    assert result == {}
+
+
+def test_normalize_tool_args_dict():
+    """Test _normalize_tool_args with dict."""
+    args = {"key": "value"}
+    result = _normalize_tool_args(args)
+    assert result == {"key": "value"}
+
+
+def test_normalize_tool_args_with_to_dict():
+    """Test _normalize_tool_args with object having to_dict method."""
+    mock_args = MagicMock()
+    mock_args.to_dict.return_value = {"key": "value"}
+    result = _normalize_tool_args(mock_args)
+    assert result == {"key": "value"}
+
+
+def test_normalize_tool_args_fallback():
+    """Test _normalize_tool_args with non-convertible object."""
+
+    class NonConvertible:
+        pass
+
+    result = _normalize_tool_args(NonConvertible())
+    assert "_raw_args" in result
+
+
+def test_create_tool_call_events():
+    """Test _create_tool_call_events creates proper A2UI events."""
+    pending_calls: list[dict] = []
+    call_id, events = _create_tool_call_events(
+        tool_name="test_tool",
+        args={"arg1": "value1"},
+        pending_tool_calls=pending_calls,
+    )
+
+    # Should have registered the pending call
+    assert len(pending_calls) == 1
+    assert pending_calls[0]["tool_name"] == "test_tool"
+    assert pending_calls[0]["args"] == {"arg1": "value1"}
+    assert call_id == pending_calls[0]["call_id"]
+
+    # Should have 2 events: beginRendering and surfaceUpdate
+    assert len(events) == 2
+
+    # Parse and verify events
+    begin_event = json.loads(events[0])
+    assert begin_event["type"] == "a2ui"
+    assert "beginRendering" in begin_event["message"]
+
+    update_event = json.loads(events[1])
+    assert update_event["type"] == "a2ui"
+    assert "surfaceUpdate" in update_event["message"]
+
+    # Verify tool log data in surfaceUpdate
+    components = update_event["message"]["surfaceUpdate"]["components"]
+    tool_log = components[0]["component"]["x-sre-tool-log"]
+    assert tool_log["tool_name"] == "test_tool"
+    assert tool_log["status"] == "running"
+    assert tool_log["args"] == {"arg1": "value1"}
+
+
+def test_create_tool_response_events_success():
+    """Test _create_tool_response_events with successful result."""
+    pending_calls = [
+        {
+            "call_id": "test_tool_abc123",
+            "tool_name": "test_tool",
+            "surface_id": "surface-123",
+            "args": {"arg1": "value1"},
+        }
+    ]
+
+    call_id, events = _create_tool_response_events(
+        tool_name="test_tool",
+        result={"result": "success"},
+        pending_tool_calls=pending_calls,
+    )
+
+    # Should have removed the pending call
+    assert len(pending_calls) == 0
+    assert call_id == "test_tool_abc123"
+
+    # Should have 1 event: surfaceUpdate with completed status
+    assert len(events) == 1
+
+    update_event = json.loads(events[0])
+    components = update_event["message"]["surfaceUpdate"]["components"]
+    tool_log = components[0]["component"]["x-sre-tool-log"]
+    assert tool_log["status"] == "completed"
+    assert tool_log["result"] == "success"
+
+
+def test_create_tool_response_events_error():
+    """Test _create_tool_response_events with error result."""
+    pending_calls = [
+        {
+            "call_id": "test_tool_abc123",
+            "tool_name": "test_tool",
+            "surface_id": "surface-123",
+            "args": {},
+        }
+    ]
+
+    _call_id, events = _create_tool_response_events(
+        tool_name="test_tool",
+        result={"error": "Something went wrong", "error_type": "RuntimeError"},
+        pending_tool_calls=pending_calls,
+    )
+
+    assert len(events) == 1
+    update_event = json.loads(events[0])
+    components = update_event["message"]["surfaceUpdate"]["components"]
+    tool_log = components[0]["component"]["x-sre-tool-log"]
+    assert tool_log["status"] == "error"
+    assert "RuntimeError" in tool_log["result"]
+
+
+def test_create_tool_response_events_no_match():
+    """Test _create_tool_response_events with no matching pending call."""
+    pending_calls = [
+        {
+            "call_id": "other_tool_abc123",
+            "tool_name": "other_tool",
+            "surface_id": "surface-123",
+            "args": {},
+        }
+    ]
+
+    call_id, events = _create_tool_response_events(
+        tool_name="test_tool",  # Different tool name
+        result={"result": "success"},
+        pending_tool_calls=pending_calls,
+    )
+
+    # Should not have matched
+    assert call_id is None
+    assert len(events) == 0
+    # Original pending call should still be there
+    assert len(pending_calls) == 1
+
+
+def test_create_tool_response_events_fifo_matching():
+    """Test that FIFO matching works for multiple calls to same tool (Fix #1)."""
+    pending_calls = [
+        {
+            "call_id": "fetch_trace_111",
+            "tool_name": "fetch_trace",
+            "surface_id": "surface-1",
+            "args": {"trace_id": "trace-1"},
+        },
+        {
+            "call_id": "fetch_trace_222",
+            "tool_name": "fetch_trace",
+            "surface_id": "surface-2",
+            "args": {"trace_id": "trace-2"},
+        },
+    ]
+
+    # First response should match first call (FIFO)
+    call_id1, events1 = _create_tool_response_events(
+        tool_name="fetch_trace",
+        result={"result": "trace-1-data"},
+        pending_tool_calls=pending_calls,
+    )
+
+    assert call_id1 == "fetch_trace_111"
+    assert len(pending_calls) == 1  # One remaining
+
+    # Verify the correct args were preserved
+    update_event = json.loads(events1[0])
+    components = update_event["message"]["surfaceUpdate"]["components"]
+    tool_log = components[0]["component"]["x-sre-tool-log"]
+    assert tool_log["args"] == {"trace_id": "trace-1"}
+
+    # Second response should match second call
+    call_id2, _events2 = _create_tool_response_events(
+        tool_name="fetch_trace",
+        result={"result": "trace-2-data"},
+        pending_tool_calls=pending_calls,
+    )
+
+    assert call_id2 == "fetch_trace_222"
+    assert len(pending_calls) == 0  # All matched
+
+
+def test_tool_widget_map_exists():
+    """Test that TOOL_WIDGET_MAP has expected tools."""
+    expected_tools = [
+        "fetch_trace",
+        "analyze_critical_path",
+        "query_promql",
+        "list_time_series",
+        "list_log_entries",
+    ]
+    for tool in expected_tools:
+        assert tool in TOOL_WIDGET_MAP
+
+
+# --- API Validation Tests (Fix #3) ---
 
 
 @pytest.mark.asyncio
-@pytest.mark.skip(
-    reason="TestClient streaming with async generators has synchronization issues. "
-    "The mock agent's run_async is called but events aren't yielded before the "
-    "response completes. This test needs refactoring to use an async test client."
-)
-async def test_genui_chat_tool_log_events():
-    """Verify that tool calls emit x-sre-tool-log events."""
+async def test_genui_chat_malformed_request_missing_text(
+    async_client: httpx.AsyncClient,
+):
+    """Verify that malformed requests without 'text' return validation errors."""
+    response = await async_client.post(
+        "/api/genui/chat",
+        json={"messages": [{"role": "user"}]},  # Missing 'text'
+    )
+    assert response.status_code == 422  # Validation error
 
-    # Mock the root_agent to yield specific events
-    # We need to mock root_agent.run_async
 
-    mock_agent = MagicMock()
+@pytest.mark.asyncio
+async def test_genui_chat_malformed_request_missing_role(
+    async_client: httpx.AsyncClient,
+):
+    """Verify that malformed requests without 'role' return validation errors."""
+    response = await async_client.post(
+        "/api/genui/chat",
+        json={"messages": [{"text": "hello"}]},  # Missing 'role'
+    )
+    assert response.status_code == 422  # Validation error
 
-    # Create mock parts for the function call and response cycle
 
-    # 1. Function Call Event
-    mock_part_call = MagicMock()
-    mock_part_call.text = None
-    mock_part_call.function_call.name = "test_tool"
-    mock_part_call.function_call.args = {"arg1": "value1"}
-    mock_part_call.function_response = None
-
-    mock_event_call = MagicMock()
-    mock_event_call.content.parts = [mock_part_call]
-
-    # 2. Function Response Event
-    mock_part_response = MagicMock()
-    mock_part_response.text = None
-    mock_part_response.function_call = None
-    mock_part_response.function_response.name = "test_tool"
-    mock_part_response.function_response.response = {"result": "success"}
-
-    mock_event_response = MagicMock()
-    mock_event_response.content.parts = [mock_part_response]
-
-    # Setup the async generator mock
-    async def mock_run_async(*args, **kwargs):
-        yield mock_event_call
-        yield mock_event_response
-
-    mock_agent.run_async = mock_run_async
-    mock_agent.clone.return_value = mock_agent  # Handle cloning
-
-    # Patch the root_agent and session manager in server.py
-    with patch("server.root_agent", mock_agent):
-        # Mock session manager to return a mock session
-        mock_session = MagicMock()
-        mock_session.id = "test-session"
-        mock_session.events = []
-
-        mock_session_manager = MagicMock()
-        mock_session_manager.get_or_create_session = AsyncMock(
-            return_value=mock_session
-        )
-        mock_session_manager.session_service.append_event = AsyncMock()
-
-        with patch("server.get_session_service", return_value=mock_session_manager):
-            # Send request
-            response = client.post(
-                "/api/genui/chat",
-                json={"messages": [{"role": "user", "text": "Run test tool"}]},
-            )
-            assert response.status_code == 200
-
-        # Parse NDJSON stream
-        lines = response.text.strip().split("\n")
-
-        tool_logs = []
-
-        for line in lines:
-            try:
-                data = json.loads(line)
-                if data.get("type") == "a2ui":
-                    msg = data.get("message", {})
-                    if "surfaceUpdate" in msg:
-                        update = msg["surfaceUpdate"]
-                        for comp in update.get("components", []):
-                            if "x-sre-tool-log" in comp.get("component", {}):
-                                tool_logs.append(comp["component"]["x-sre-tool-log"])
-            except Exception:
-                pass
-
-        # Assertions
-        assert len(tool_logs) >= 2, (
-            "Should have at least 2 tool log events (running, completed)"
-        )
-
-        # Check first log (running)
-        running_log = tool_logs[0]
-        assert running_log["tool_name"] == "test_tool"
-        assert running_log["status"] == "running"
-        assert running_log["args"] == {"arg1": "value1"}
-
-        # Check second log (completed)
-        # Find the one with status completed (iteration order in list might correspond to emission)
-        completed_log = next(
-            (log for log in tool_logs if log["status"] == "completed"), None
-        )
-        assert completed_log is not None
-        assert completed_log["tool_name"] == "test_tool"
-        # Server unwraps {"result": "val"} to "val"
-        assert completed_log["result"] == "success"
+@pytest.mark.asyncio
+async def test_genui_chat_valid_request_format(async_client: httpx.AsyncClient):
+    """Verify that valid request format is accepted."""
+    # This tests that the request validation accepts the correct format
+    # The actual agent execution may fail, but the request should be validated
+    response = await async_client.post(
+        "/api/genui/chat",
+        json={"messages": [{"role": "user", "text": "Hello"}]},
+    )
+    # Should be accepted (200 OK for streaming) not a validation error (422)
+    assert response.status_code == 200


### PR DESCRIPTION
… names

The genui chat endpoint was experiencing tool call loops because the `active_tools` dict was keyed by tool name, causing multiple calls to the same tool to overwrite each other's tracking state.

Changes:
- Replace `active_tools: dict[str, dict]` with `pending_tool_calls: list[dict]` using unique call_id (e.g., `fetch_trace_abc12345`) for FIFO matching
- Extract duplicated tool handling code into shared helpers: `_normalize_tool_args()`, `_create_tool_call_events()`, `_create_tool_response_events()`, and `TOOL_WIDGET_MAP`
- Add `ChatMessage` Pydantic model for strict request validation
- Replace skipped test with 13 working unit tests covering tool event helpers, FIFO matching, and API validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)