### PR TITLE
Fix Trace Analysis feature backend integration

### DIFF
--- a/autosre/lib/catalog.dart
+++ b/autosre/lib/catalog.dart
@@ -28,7 +28,14 @@ class CatalogRegistry {
           dataSchema: S.object(),
           widgetBuilder: (context) {
             try {
-              final data = _ensureMap(context.data);
+              var data = _ensureMap(context.data);
+
+              // Handle case where data might be wrapped in component name
+              // (e.g., {"x-sre-trace-waterfall": {...actual data...}})
+              if (data.containsKey('x-sre-trace-waterfall') && data['x-sre-trace-waterfall'] is Map) {
+                data = Map<String, dynamic>.from(data['x-sre-trace-waterfall'] as Map);
+              }
+
               final trace = Trace.fromJson(data);
               return _buildWidgetContainer(
                 child: TraceWaterfall(trace: trace),

--- a/server.py
+++ b/server.py
@@ -1436,6 +1436,21 @@ def _create_widget_events(tool_name: str, result: Any) -> list[str]:
             logger.warning(f"Failed to parse widget result as JSON: {e}")
             return []
 
+    # Apply data transformations to match Flutter widget expectations
+    if isinstance(data, dict):
+        if component_name == "x-sre-trace-waterfall":
+            data = genui_adapter.transform_trace(data)
+            logger.debug(f"Transformed trace data: {len(data.get('spans', []))} spans")
+        elif component_name == "x-sre-metric-chart":
+            data = genui_adapter.transform_metrics(data)
+        elif component_name == "x-sre-log-pattern-viewer":
+            if "top_patterns" in data:
+                data = data["top_patterns"]
+        elif component_name == "x-sre-log-entries-viewer":
+            data = genui_adapter.transform_log_entries(data)
+        elif component_name == "x-sre-remediation-plan":
+            data = genui_adapter.transform_remediation(data)
+
     events = [
         json.dumps(
             {

--- a/tests/integration/test_chat_persistence.py
+++ b/tests/integration/test_chat_persistence.py
@@ -76,9 +76,9 @@ async def test_chat_endpoint_persists_user_role(client):
 
             user_event = user_events[0]
             # This is the critical check
-            assert (
-                user_event.content.role == "user"
-            ), "User role was not persisted correctly"
+            assert user_event.content.role == "user", (
+                "User role was not persisted correctly"
+            )
             assert user_event.content.parts[0].text == "Hello persistence"
 
     finally:

--- a/tests/unit/sre_agent/test_schema_compliance.py
+++ b/tests/unit/sre_agent/test_schema_compliance.py
@@ -35,9 +35,9 @@ def test_no_complex_union_with_dict_in_tools():
             if "Union" in type_str and "dict" in type_str:
                 suspicious_tools.append(f"{tool_name}.{param_name}: {type_str}")
 
-    assert (
-        not suspicious_tools
-    ), f"Found tools with risky Union+Dict types: {suspicious_tools}"
+    assert not suspicious_tools, (
+        f"Found tools with risky Union+Dict types: {suspicious_tools}"
+    )
 
 
 def test_no_tool_context_type_in_signatures():
@@ -59,7 +59,9 @@ def test_no_tool_context_type_in_signatures():
             elif param_type is ToolContext:
                 tools_with_context.append(f"{tool_name}.{param_name}")
 
-    assert not tools_with_context, f"Found tools exposing ToolContext in signature (use Any instead): {tools_with_context}"
+    assert not tools_with_context, (
+        f"Found tools exposing ToolContext in signature (use Any instead): {tools_with_context}"
+    )
 
 
 def test_detect_metric_anomalies_signature_safe():
@@ -72,9 +74,9 @@ def test_detect_metric_anomalies_signature_safe():
     data_points_type = hints.get("data_points")
 
     # parameters should be list[float], not a Union
-    assert (
-        data_points_type == list[float]
-    ), f"detect_metric_anomalies data_points type is {data_points_type}, expected list[float]"
+    assert data_points_type == list[float], (
+        f"detect_metric_anomalies data_points type is {data_points_type}, expected list[float]"
+    )
 
 
 def test_run_analysis_tools_signature_safe():
@@ -99,9 +101,9 @@ def test_run_analysis_tools_signature_safe():
 
         # Should be Any or Any | None, definitely NOT ToolContext
         type_str = str(tool_context_type)
-        assert (
-            "ToolContext" not in type_str
-        ), f"{tool.__name__} has ToolContext in signature: {type_str}"
+        assert "ToolContext" not in type_str, (
+            f"{tool.__name__} has ToolContext in signature: {type_str}"
+        )
 
 
 def test_mcp_tools_signature_safe():
@@ -125,6 +127,6 @@ def test_mcp_tools_signature_safe():
         tool_context_type = hints.get("tool_context")
 
         type_str = str(tool_context_type)
-        assert (
-            "ToolContext" not in type_str
-        ), f"{tool.__name__} has ToolContext in signature: {type_str}"
+        assert "ToolContext" not in type_str, (
+            f"{tool.__name__} has ToolContext in signature: {type_str}"
+        )

--- a/tests/unit/sre_agent/tools/analysis/bigquery/test_bigquery_otel.py
+++ b/tests/unit/sre_agent/tools/analysis/bigquery/test_bigquery_otel.py
@@ -289,9 +289,9 @@ class TestBigQueryOtelTools:
             if "error" in result_data:
                 continue
 
-            assert (
-                "description" in result_data
-            ), f"{tool_func.__name__} missing description"
-            assert (
-                "next_steps" in result_data
-            ), f"{tool_func.__name__} missing next_steps"
+            assert "description" in result_data, (
+                f"{tool_func.__name__} missing description"
+            )
+            assert "next_steps" in result_data, (
+                f"{tool_func.__name__} missing next_steps"
+            )

--- a/tests/unit/sre_agent/tools/analysis/logs/test_patterns.py
+++ b/tests/unit/sre_agent/tools/analysis/logs/test_patterns.py
@@ -65,9 +65,9 @@ class TestLogPatternExtractor:
 
         # Most should cluster together (Drain3 may split first few)
         unique_patterns = len(set(ids))
-        assert (
-            unique_patterns <= 3
-        ), f"Expected at most 3 patterns, got {unique_patterns}"
+        assert unique_patterns <= 3, (
+            f"Expected at most 3 patterns, got {unique_patterns}"
+        )
 
         # Total count should match
         total_count = sum(p.count for p in extractor.patterns.values())


### PR DESCRIPTION
The trace waterfall widget was showing "No spans in trace" even when the backend returned valid trace data with spans. This fix addresses multiple potential failure points in the A2UI data flow:

1. Dart Trace.fromJson: Made parsing more robust to handle null/missing spans gracefully instead of throwing exceptions. The previous `json['spans'] as List` cast would fail if spans was null or unexpected type.

2. Flutter catalog.dart: Added fallback to handle case where genui library might pass data wrapped in the component name (e.g., {"x-sre-trace-waterfall": {...actual data...}}).

3. Python _create_widget_events: Added missing data transformations that were present in inline code paths but not in this helper function. Though currently unused, this prevents a bug if the function is later used.

Also includes minor code formatting improvements from ruff in test files.