### PR TITLE
Add error handling for Agent Engine stream failures and encryption key mismatches

### DIFF
--- a/autosre/lib/agent/adk_content_generator.dart
+++ b/autosre/lib/agent/adk_content_generator.dart
@@ -209,6 +209,21 @@ class ADKContentGenerator implements ContentGenerator {
 
                 if (type == 'text') {
                   _textController.add(data['content']);
+                } else if (type == 'error') {
+                  // Handle error events from backend
+                  final errorMessage = data['error'] as String? ?? 'Unknown error';
+                  debugPrint('⚠️ Agent error received: $errorMessage');
+
+                  // Show error in chat as text
+                  _textController.add('\n\n**Error:** $errorMessage\n');
+
+                  // Also emit to error stream for StatusToast notification
+                  _errorController.add(
+                    ContentGeneratorError(
+                      Exception(errorMessage),
+                      StackTrace.current,
+                    ),
+                  );
                 } else if (type == 'a2ui') {
                   final msgJson = data['message'] as Map<String, dynamic>;
                   final msg = A2uiMessage.fromJson(msgJson);

--- a/autosre/lib/pages/conversation_page.dart
+++ b/autosre/lib/pages/conversation_page.dart
@@ -182,7 +182,13 @@ class _ConversationPageState extends State<ConversationPage>
     // Subscribe to errors
     _contentGenerator.errorStream.listen((error) {
       if (mounted) {
-        StatusToast.show(context, 'Error: ${error.error}');
+        // Show error toast with isError=true for proper styling
+        StatusToast.show(
+          context,
+          'Agent Error: ${error.error}',
+          isError: true,
+          duration: const Duration(seconds: 5),
+        );
         debugPrint(
           'ContentGenerator Error: ${error.error}\n${error.stackTrace}',
         );

--- a/tests/unit/sre_agent/test_auth_encryption.py
+++ b/tests/unit/sre_agent/test_auth_encryption.py
@@ -71,3 +71,42 @@ def test_transient_key_fallback():
             encrypted = encrypt_token(token)
             decrypted = decrypt_token(encrypted)
             assert decrypted == token
+
+
+def test_decryption_key_mismatch_returns_empty():
+    """Test that decryption with wrong key returns empty string for Fernet tokens.
+
+    This prevents sending encrypted gibberish to downstream APIs when there's
+    an encryption key mismatch between services (Cloud Run vs Agent Engine).
+    """
+    # Create a token that looks like a valid Fernet token (>50 chars, starts with gAAAA)
+    # but with invalid/corrupted data that can't be decrypted
+    invalid_fernet = (
+        "gAAAAABpddLuv-invalid-fernet-token-with-enough-characters-to-look-real-"
+        "and-trigger-the-decryption-path-in-our-code-0123456789"
+    )
+    assert len(invalid_fernet) > 50
+    assert invalid_fernet.startswith("gAAAA")
+
+    decrypted = decrypt_token(invalid_fernet)
+    # Should return empty string, NOT the encrypted gibberish
+    assert decrypted == ""
+
+
+def test_get_credentials_from_session_key_mismatch_returns_none():
+    """Test that session credentials return None when decryption fails.
+
+    When there's an encryption key mismatch, get_credentials_from_session
+    should return None rather than invalid Credentials with gibberish token.
+    """
+    # Create a token that looks like a valid Fernet token but can't be decrypted
+    invalid_fernet = (
+        "gAAAAABpddLuv-invalid-fernet-token-with-enough-characters-to-look-real-"
+        "and-trigger-the-decryption-path-in-our-code-0123456789"
+    )
+
+    session_state = {SESSION_STATE_ACCESS_TOKEN_KEY: invalid_fernet}
+    creds = get_credentials_from_session(session_state)
+
+    # Should return None instead of Credentials with invalid token
+    assert creds is None


### PR DESCRIPTION
## Summary
This PR improves error handling and user experience when Agent Engine stream processing fails, particularly in cases of authentication issues or encryption key mismatches between services. It adds comprehensive error catching, user-friendly error messages, and prevents invalid credentials from being created with corrupted tokens.

## Key Changes

### Backend Error Handling (Python)
- **agent_engine_client.py**: Added try-catch blocks around all Agent Engine stream processing paths to handle:
  - `ValueError` exceptions from malformed JSON responses (common when Agent Engine returns errors)
  - `AttributeError` exceptions when SDK receives invalid response formats
  - Yields structured error events (`type: "error"`) that propagate to the frontend
  
- **auth.py**: Enhanced token decryption to prevent sending encrypted gibberish to downstream APIs:
  - `decrypt_token()` now returns empty string when decryption fails for Fernet-encrypted tokens (instead of returning the encrypted token)
  - `get_credentials_from_session()` validates decrypted tokens and returns `None` if decryption failed, preventing creation of invalid credentials
  - Improved logging to clarify encryption key mismatch scenarios

### Frontend Error Handling (Flutter)
- **adk_content_generator.dart**: Added handler for `type: "error"` events from backend:
  - Displays error message in chat UI
  - Emits to error stream for toast notifications
  
- **conversation_page.dart**: Enhanced error toast display:
  - Uses `isError: true` flag for proper error styling
  - Extended duration to 5 seconds for better visibility
  - More descriptive error prefix

### Tests
- Added `test_decryption_key_mismatch_returns_empty()` to verify empty string is returned for corrupted Fernet tokens
- Added `test_get_credentials_from_session_key_mismatch_returns_none()` to verify credentials aren't created with invalid tokens

## Implementation Details
- Error messages guide users to common solutions (sign out/in, check encryption key configuration)
- All three streaming code paths (async with stream_query, async with fallback, sync iterator) have consistent error handling
- Errors are caught at the stream level to prevent entire request from failing silently