### PR TITLE
feat: add frontend selection (Flutter vs React)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,9 @@ RUN uv pip install --system --no-cache . uvicorn fastapi google-adk google-cloud
 COPY --from=builder /app/autosre/build/web ./web/
 
 # 3. Setup React AgentOps UI (from react-builder)
+# Available at both paths: agent_graph_web (legacy /graph) and react_web (for SRE_FRONTEND=react)
 COPY --from=react-builder /app/agent_ops_ui/dist ./agent_graph_web/
+COPY --from=react-builder /app/agent_ops_ui/dist ./react_web/
 
 # 4. Startup Script
 COPY scripts/start_unified.sh .

--- a/README.md
+++ b/README.md
@@ -305,8 +305,14 @@ python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().d
 ### 3. Running Locally
 
 ```bash
-# Full stack: FastAPI backend + Flutter web frontend
+# Full stack: FastAPI backend + Flutter + React frontends
 uv run poe dev
+
+# React frontend only (+ backend)
+uv run poe dev-react
+
+# Flutter frontend only (+ backend)
+uv run poe dev-flutter
 
 # Backend API server only (FastAPI on port 8001)
 uv run poe web
@@ -315,7 +321,7 @@ uv run poe web
 uv run poe run
 ```
 
-The full stack starts the FastAPI backend and the Flutter web frontend together. The agent runs in-process for fast iteration -- no Vertex AI deployment required.
+The full stack starts the FastAPI backend and both web frontends together. The agent runs in-process for fast iteration -- no Vertex AI deployment required. In production, set `SRE_FRONTEND=react` to serve the React UI at `/` instead of Flutter. See the [Frontend Selection guide](docs/guides/frontend_selection.md) for details.
 
 > [!TIP]
 > To enable local Cloud Trace export, set `OTEL_TO_CLOUD=true` in your `.env` file.

--- a/deploy/Dockerfile.unified
+++ b/deploy/Dockerfile.unified
@@ -45,7 +45,9 @@ RUN uv pip install --system --no-cache . uvicorn fastapi google-adk google-cloud
 COPY --from=builder /app/autosre/build/web ./web/
 
 # 3. Setup React AgentOps UI (from react-builder)
+# Available at both paths: agent_graph_web (legacy /graph) and react_web (for SRE_FRONTEND=react)
 COPY --from=react-builder /app/agent_ops_ui/dist ./agent_graph_web/
+COPY --from=react-builder /app/agent_ops_ui/dist ./react_web/
 
 # 4. Startup Script
 COPY scripts/start_unified.sh .

--- a/docs/guides/frontend_selection.md
+++ b/docs/guides/frontend_selection.md
@@ -1,0 +1,64 @@
+# Frontend Selection
+
+Auto SRE ships with two frontends:
+
+| Frontend | Stack | Purpose |
+|----------|-------|---------|
+| **Flutter** | Dart, Material 3, Riverpod | Full investigation dashboard with GenUI, traces, council visualization |
+| **React** | TypeScript, Vite, React Flow, ECharts | Agent operations dashboard with topology, trajectory, metrics |
+
+By default both frontends are available: Flutter at `/` and React at `/graph`.
+
+## Development
+
+```bash
+# Both frontends (default)
+uv run poe dev
+
+# React frontend + backend only
+uv run poe dev-react
+
+# Flutter frontend + backend only
+uv run poe dev-flutter
+
+# Backend API only (no frontend)
+uv run poe web
+```
+
+Dev ports:
+- Backend API: `http://localhost:8001`
+- Flutter: `http://localhost:8080` (when active)
+- React: `http://localhost:5174` (when active)
+
+## Production
+
+Set the `SRE_FRONTEND` environment variable to control which frontend is primary:
+
+| Value | `/` serves | `/graph` or `/flutter` |
+|-------|-----------|----------------------|
+| `both` (default) | Flutter | React at `/graph` |
+| `flutter` | Flutter | React at `/graph` |
+| `react` | React | Flutter at `/flutter` |
+
+### Cloud Run
+
+```bash
+gcloud run deploy sre-agent \
+  --set-env-vars SRE_FRONTEND=react
+```
+
+### GKE
+
+Add to your deployment manifest:
+
+```yaml
+env:
+  - name: SRE_FRONTEND
+    value: "react"
+```
+
+### Docker
+
+```bash
+docker run -e SRE_FRONTEND=react sre-agent
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,8 @@ agent_directory = "sre_agent"
 
 [tool.poe.tasks]
 dev = { help = "Run the full dev stack (backend + frontend)", cmd = "python scripts/start_dev.py", envfile = ".env" }
+dev-react = { help = "Dev stack with React frontend only", cmd = "python scripts/start_dev.py --frontend react", envfile = ".env" }
+dev-flutter = { help = "Dev stack with Flutter frontend only", cmd = "python scripts/start_dev.py --frontend flutter", envfile = ".env" }
 update-docs = { help = "Update llm.txt docs index and generate repo_map.txt", cmd = "python scripts/update_docs_index.py" }
 sync = { help = "Sync all dependencies (uv + flutter + npm)", sequence = ["_sync_uv", "_sync_flutter", "_sync_npm"] }
 _sync_uv = { cmd = "uv sync" }

--- a/scripts/start_dev.py
+++ b/scripts/start_dev.py
@@ -1,3 +1,4 @@
+import argparse
 import os
 import shutil
 import signal
@@ -186,26 +187,49 @@ def start_react() -> bool:
     return True
 
 
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(description="SRE Agent Development Environment")
+    parser.add_argument(
+        "--frontend",
+        choices=["flutter", "react", "both"],
+        default="both",
+        help="Which frontend to start (default: both)",
+    )
+    return parser.parse_args()
+
+
 def main() -> None:
     """Run the development environment."""
+    args = parse_args()
+
     # Register signal handlers
     signal.signal(signal.SIGINT, cleanup)
     signal.signal(signal.SIGTERM, cleanup)
 
+    frontend_label = {
+        "both": "Flutter + React frontends",
+        "flutter": "Flutter frontend only",
+        "react": "React frontend only",
+    }[args.frontend]
+
     print("🔥 Starting SRE Agent Development Environment...")
+    print(f"   Frontend mode: {frontend_label}")
     print("===============================================")
 
     if not start_backend():
         cleanup(None, None)
         return
 
-    if not start_frontend():
-        cleanup(None, None)
-        return
+    if args.frontend in ("flutter", "both"):
+        if not start_frontend():
+            cleanup(None, None)
+            return
 
-    if not start_react():
-        cleanup(None, None)
-        return
+    if args.frontend in ("react", "both"):
+        if not start_react():
+            cleanup(None, None)
+            return
 
     print("\n✅ API running at http://127.0.0.1:8001")
     if frontend_proc:

--- a/sre_agent/api/app.py
+++ b/sre_agent/api/app.py
@@ -105,20 +105,50 @@ def create_app(
     if include_adk_routes:
         _mount_adk_routes(app)
 
-    # Mount React Agent Graph UI at /graph (before Flutter catch-all)
-    if os.path.exists("agent_graph_web"):
-        app.mount(
-            "/graph",
-            StaticFiles(directory="agent_graph_web", html=True),
-            name="agent_graph",
-        )
-        logger.info("Mounted Agent Graph UI from 'agent_graph_web' at /graph")
+    # Mount frontend static files based on SRE_FRONTEND env var
+    # Values: "flutter" (default), "react", "both"
+    sre_frontend = os.environ.get("SRE_FRONTEND", "both").lower()
 
-    # Mount static files for the frontend if they exist
-    # In Cloud Run, the build artifacts are copied to /app/web
-    if os.path.exists("web"):
-        app.mount("/", StaticFiles(directory="web", html=True), name="web")
-        logger.info("Mounted static files from 'web' directory")
+    if sre_frontend == "react":
+        # React is primary at /, Flutter demoted to /flutter
+        if os.path.exists("web"):
+            app.mount(
+                "/flutter",
+                StaticFiles(directory="web", html=True),
+                name="web",
+            )
+            logger.info("Mounted Flutter UI at /flutter")
+        # Try react_web first (new path), fall back to agent_graph_web (legacy)
+        if os.path.exists("react_web"):
+            app.mount(
+                "/",
+                StaticFiles(directory="react_web", html=True),
+                name="react",
+            )
+            logger.info("Mounted React UI from 'react_web' at /")
+        elif os.path.exists("agent_graph_web"):
+            app.mount(
+                "/",
+                StaticFiles(directory="agent_graph_web", html=True),
+                name="react",
+            )
+            logger.info("Mounted React UI from 'agent_graph_web' at /")
+    else:
+        # "flutter" or "both": Flutter is primary at /, React at /graph
+        if os.path.exists("agent_graph_web"):
+            app.mount(
+                "/graph",
+                StaticFiles(directory="agent_graph_web", html=True),
+                name="agent_graph",
+            )
+            logger.info("Mounted React UI from 'agent_graph_web' at /graph")
+        if os.path.exists("web"):
+            app.mount(
+                "/",
+                StaticFiles(directory="web", html=True),
+                name="web",
+            )
+            logger.info("Mounted Flutter UI at /")
 
     return app
 


### PR DESCRIPTION
## Summary

- Add `--frontend` flag to `scripts/start_dev.py` accepting `flutter`, `react`, or `both` (default: `both`)
- Add `dev-react` and `dev-flutter` poe tasks for convenience
- Add `SRE_FRONTEND` env var in production to control which frontend serves at `/`
- Dual-copy React build in Dockerfiles so both `agent_graph_web/` and `react_web/` paths work
- New `docs/guides/frontend_selection.md` guide

## Test plan

- [ ] `uv run poe dev` — both frontends start (unchanged behavior)
- [ ] `uv run poe dev-react` — only React + backend start
- [ ] `uv run poe dev-flutter` — only Flutter + backend start
- [ ] `SRE_FRONTEND=react` with `react_web/` dir present — React serves at `/`
- [ ] `uv run poe lint` — passes
- [ ] `uv run poe test-fast` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)