### PR TITLE
⚡ Bolt: Offload ID token verification to threadpool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+
+## 2025-02-18 - [Offload Synchronous OAuth Verification]
+**Learning:** `google.oauth2.id_token.verify_oauth2_token` is synchronous and can perform network I/O to fetch Google's public keys. When called directly within an `async def` FastAPI endpoint (or middleware like `validate_id_token`), it can block the entire async event loop.
+**Action:** Always wrap synchronous functions that might perform I/O (like auth library calls) in `fastapi.concurrency.run_in_threadpool` to maintain concurrent performance in async contexts.

--- a/sre_agent/auth.py
+++ b/sre_agent/auth.py
@@ -841,7 +841,17 @@ async def validate_id_token(id_token_str: str) -> TokenInfo:
         # Local signature verification and claim extraction
         # SECURITY: Specifying audience (GOOGLE_CLIENT_ID) prevents ID token substitution attacks
         client_id = os.environ.get("GOOGLE_CLIENT_ID")
-        idinfo = id_token.verify_oauth2_token(id_token_str, request, audience=client_id)  # type: ignore[no-untyped-call]
+
+        from fastapi.concurrency import run_in_threadpool
+
+        # Offload synchronous token verification to threadpool to prevent blocking event loop
+        # when fetching Google's public keys
+        idinfo = await run_in_threadpool(
+            id_token.verify_oauth2_token,
+            id_token_str,
+            request,
+            audience=client_id,
+        )
 
         info = TokenInfo(
             valid=True,


### PR DESCRIPTION
💡 What: Wrapped `id_token.verify_oauth2_token` with `fastapi.concurrency.run_in_threadpool` in `validate_id_token`.
🎯 Why: The function is synchronous and can perform blocking network I/O to fetch Google's public keys, which would halt the FastAPI event loop during authentication requests.
📊 Impact: Prevents event loop blocking, improving concurrent request handling and reducing latency spikes for other users under high authentication load.
🔬 Measurement: Run load tests or observe improved P99 latency during concurrent authentication bursts.

---
*PR created automatically by Jules for task [3271641806825055083](https://jules.google.com/task/3271641806825055083) started by @srtux*