### PR TITLE
Docs: update links, paths, and test counts across README and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <img src="https://img.shields.io/badge/Python-3.10%2B_<%2F3.13-blue" alt="Python">
   <img src="https://img.shields.io/badge/Frontend-Flutter_Web-02569B" alt="Frontend">
   <img src="https://img.shields.io/badge/GCP-Native-4285F4" alt="GCP">
-  <img src="https://img.shields.io/badge/Tests-2429_backend_|_129_flutter-brightgreen" alt="Tests">
+  <img src="https://img.shields.io/badge/Tests-239_py_files_|_41_flutter_files-brightgreen" alt="Tests">
 </div>
 
 ---
@@ -772,7 +772,7 @@ See [AGENTS.md](AGENTS.md) for the complete coding standard.
 
 ## License
 
-Apache-2.0. See [LICENSE](LICENSE) for details.
+Apache-2.0.
 
 ---
 

--- a/autosre/README.md
+++ b/autosre/README.md
@@ -23,7 +23,7 @@ It is designed to be served by the unified SRE Agent server, but can also be run
 
 - **Flutter SDK** (Dart SDK ^3.10.7): [Install Flutter](https://docs.flutter.dev/get-started/install)
 - **SRE Agent Backend**: Run via `uv run poe dev` (unified) or `uv run poe web` (backend only).
-- **Troubleshooting**: See [docs/debugging_connectivity.md](../docs/debugging_connectivity.md) for connection issues.
+- **Troubleshooting**: See [docs/debugging/debugging_connectivity.md](../docs/debugging/debugging_connectivity.md) for connection issues.
 
 ## Getting Started
 
@@ -57,7 +57,7 @@ It is designed to be served by the unified SRE Agent server, but can also be run
 
 - **Framework**: Flutter (Material 3)
 - **Protocol**: [GenUI](https://github.com/flutter/genui) + [A2UI](https://a2ui.org)
-- **State Management**: Provider (`ChangeNotifier` pattern)
+- **State Management**: Hybrid transition -- Riverpod (feature-first modules) and legacy Provider/ChangeNotifier services.
 - **Entry Point**: `lib/main.dart`
 - **App Configuration**: `lib/app.dart`
 - **Catalog Registry**: `lib/catalog.dart` (maps A2UI component types to Flutter widgets)

--- a/docs/IMPROVEMENTS.md
+++ b/docs/IMPROVEMENTS.md
@@ -1,6 +1,6 @@
 # SRE Agent Improvements
 
-> **Note**: This content has been integrated into [docs/PROJECT_PLAN.md](docs/PROJECT_PLAN.md) under "Phase 2.5: SRE Reliability Suite". This file is kept for historical reference. For the living roadmap, see PROJECT_PLAN.md.
+> **Note**: This content has been integrated into [docs/PROJECT_PLAN.md](PROJECT_PLAN.md) under "Phase 2.5: SRE Reliability Suite". This file is kept for historical reference. For the living roadmap, see PROJECT_PLAN.md.
 
 This document details the improvements made to elevate the Auto SRE Agent toward world-class reliability engineering automation, following Google SRE best practices.
 
@@ -22,7 +22,7 @@ Total: **105 new tests**, all passing.
 
 ## Completed Optimizations (OPT-1 through OPT-10)
 
-In addition to the five features above, ten optimization passes were applied to the agent architecture. All are tracked in detail in [docs/architecture/AGENTS_AND_TOOLS.md](docs/architecture/AGENTS_AND_TOOLS.md).
+In addition to the five features above, ten optimization passes were applied to the agent architecture. All are tracked in detail in [docs/architecture/AGENTS_AND_TOOLS.md](architecture/AGENTS_AND_TOOLS.md).
 
 | ID | Optimization | Status |
 |----|-------------|--------|

--- a/docs/PROJECT_PLAN.md
+++ b/docs/PROJECT_PLAN.md
@@ -7,7 +7,7 @@ This document is the **Single Source of Truth** for the project's evolution. It 
 ## Executive Summary
 Auto SRE is an autonomous reliability engine for Google Cloud. It has evolved from a monolithic, reactive tool into a modular, proactive, and memory-aware diagnostic expert with a Council of Experts architecture, self-healing capabilities, and an interactive Observability Explorer dashboard.
 
-**Current state**: 2312 backend tests across 196 test files, 129 Flutter tests across 22 test files. Phase 3 complete; Phase 4 in progress.
+**Current state**: 239 Python test files and 41 Flutter test files. Phase 3 complete; Phase 4 in progress.
 
 ---
 

--- a/docs/agent_ops/architecture.md
+++ b/docs/agent_ops/architecture.md
@@ -6,7 +6,7 @@ As AI agents evolve from single-prompt models into multi-agent orchestration sys
 
 This document describes the theory, strategy, and implementation of Auto SRE's Agent Graph — a property graph visualization built on BigQuery `GRAPH_TABLE` that aggregates multi-trace telemetry into an interactive, explorable topology of agent behavior. It covers the full data pipeline from OpenTelemetry span emission through BigQuery materialized views and pre-aggregated hourly tables, to two complementary visualization surfaces: a React Flow topology graph and a Nivo Sankey trajectory diagram. It details the SQL constructs — recursive CTEs, property graph path matching, model-specific cost estimation, and deduplication-safe scheduled queries — that make sub-second multi-trace aggregation possible. It describes the use cases that make this system indispensable for debugging, cost optimization, and architectural understanding of production reasoning systems.
 
-> **See also**: [Multi-Agent Observability](multi_agent_observability.md) for a high-level overview of how the Agent Graph fits within Auto SRE's broader observability strategy.
+> **See also**: [Multi-Agent Observability](observability_theory.md) for a high-level overview of how the Agent Graph fits within Auto SRE's broader observability strategy.
 
 ---
 

--- a/docs/agent_ops/observability_theory.md
+++ b/docs/agent_ops/observability_theory.md
@@ -29,7 +29,7 @@ Two complementary views are provided:
 
 **Best for**: Architecture understanding, cost optimization, error investigation, latency bottleneck identification, regression detection, loop detection.
 
-Full documentation: [Agent Graph](agent_graph.md)
+Full documentation: [Agent Graph](architecture.md)
 
 ### AgentOps Dashboard
 
@@ -66,7 +66,7 @@ These tools integrate with the **self-healing OODA loop** -- a closed-loop archi
 
 **Best for**: Automated self-improvement, anti-pattern detection, token waste identification, scheduled health analysis.
 
-Full documentation: [Online Research & Self-Healing](online_research_and_self_healing.md)
+Full documentation: [Online Research & Self-Healing](../concepts/online_research_and_self_healing.md)
 
 ---
 
@@ -156,7 +156,7 @@ Key capabilities:
 
 The Agent Graph React UI lives at `agent_ops_ui/` and communicates with FastAPI endpoints at `/api/v1/graph/*` (topology, trajectories, node detail, edge detail, timeseries).
 
-For the full data pipeline walkthrough, BigQuery schema details, SQL constructs, and use case catalog, see [Agent Graph](agent_graph.md).
+For the full data pipeline walkthrough, BigQuery schema details, SQL constructs, and use case catalog, see [Agent Graph](architecture.md).
 
 ---
 
@@ -217,7 +217,7 @@ Anti-patterns detected by the self-analysis tools include:
 
 Safety guardrails ensure human oversight: all agent-generated PRs are drafts by default, branch names must start with `auto-fix/`, PRs are labeled `agent-generated` and `auto-fix`, and the CI/CD pipeline validates changes before deployment.
 
-For the full OODA loop architecture, GitHub tool details, and safety guardrails, see [Online Research & Self-Healing](online_research_and_self_healing.md).
+For the full OODA loop architecture, GitHub tool details, and safety guardrails, see [Online Research & Self-Healing](../concepts/online_research_and_self_healing.md).
 
 ---
 
@@ -293,7 +293,7 @@ Run the one-time BigQuery setup script to create the materialized view, SQL view
 ./scripts/setup_agent_graph_bq.sh <project_id> <trace_dataset> [graph_dataset]
 ```
 
-Then configure a BigQuery Scheduled Query to run every hour for incremental updates. See [Agent Graph -- Setup and Deployment](agent_graph.md#10-setup-and-deployment) for detailed instructions.
+Then configure a BigQuery Scheduled Query to run every hour for incremental updates. See [Agent Graph -- Setup and Deployment](architecture.md#10-setup-and-deployment) for detailed instructions.
 
 ### Step 2: Start the AgentOps UI
 
@@ -318,7 +318,7 @@ The self-analysis tools require BigQuery access and are available as standard `@
 #   detect_agent_anti_patterns(trace_id=<each trace>)
 ```
 
-For the self-healing loop (GitHub integration), configure `GITHUB_TOKEN` and `GITHUB_REPO` environment variables. See [Online Research & Self-Healing -- Configuration](online_research_and_self_healing.md) for details.
+For the self-healing loop (GitHub integration), configure `GITHUB_TOKEN` and `GITHUB_REPO` environment variables. See [Online Research & Self-Healing -- Configuration](../concepts/online_research_and_self_healing.md) for details.
 
 ### Step 4: Explore
 
@@ -335,11 +335,11 @@ For the self-healing loop (GitHub integration), configure `GITHUB_TOKEN` and `GI
 
 ## Related Documentation
 
-- [Agent Graph](agent_graph.md) -- Full data pipeline, BigQuery schema, visualization architecture, and use cases
+- [Agent Graph](architecture.md) -- Full data pipeline, BigQuery schema, visualization architecture, and use cases
 - [AgentOps Dashboard Guide](../agent_ops/dashboard.md) -- Dashboard sections, data flow, and testing
-- [Online Research & Self-Healing](online_research_and_self_healing.md) -- OODA loop, GitHub tools, and safety guardrails
-- [Observability and OpenTelemetry Concepts](observability.md) -- Foundational OTel concepts (traces, logs, metrics, changes)
-- [Agent Orchestration](agent_orchestration.md) -- Council of Experts architecture
+- [Online Research & Self-Healing](../concepts/online_research_and_self_healing.md) -- OODA loop, GitHub tools, and safety guardrails
+- [Observability and OpenTelemetry Concepts](../concepts/observability.md) -- Foundational OTel concepts (traces, logs, metrics, changes)
+- [Agent Orchestration](../concepts/agent_orchestration.md) -- Council of Experts architecture
 - [Configuration Reference](../reference/configuration.md) -- Environment variables
 
 ---

--- a/docs/architecture/AGENTS_AND_TOOLS.md
+++ b/docs/architecture/AGENTS_AND_TOOLS.md
@@ -323,8 +323,8 @@ Both sub-agents and council panels import from this single registry to prevent t
 | [`list_alert_policies`](../../sre_agent/tools/clients/monitoring.py) | `tools/clients/monitoring.py` | Root, Alert Analyst, Alerts Panel |
 | [`get_alert`](../../sre_agent/tools/clients/monitoring.py) | `tools/clients/monitoring.py` | Root, Alert Analyst, Alerts Panel |
 | [`list_slos`](../../sre_agent/tools/clients/monitoring.py) | `tools/clients/monitoring.py` | Root |
-| [`list_gcp_projects`](../../sre_agent/tools/clients/resource_manager.py) | `tools/clients/resource_manager.py` | Root |
-| [`list_error_events`](../../sre_agent/tools/clients/error_reporting.py) | `tools/clients/error_reporting.py` | Root |
+| [`list_gcp_projects`](../../sre_agent/tools/clients/gcp_projects.py) | `tools/clients/gcp_projects.py` | Root |
+| [`list_error_events`](../../sre_agent/tools/clients/logging.py) | `tools/clients/logging.py` | Root |
 
 ### Trace Analysis (13 tools)
 
@@ -511,7 +511,7 @@ Both sub-agents and council panels import from this single registry to prevent t
 
 | Tool | Code Path | Used By |
 |:-----|:----------|:--------|
-| [`get_current_time`](../../sre_agent/tools/common/time.py) | `tools/common/time.py` | Root, Agent Debugger |
+| [`get_current_time`](../../sre_agent/tools/clients/trace.py) | `tools/clients/trace.py` | Root, Agent Debugger |
 | [`get_golden_signals`](../../sre_agent/tools/clients/slo.py) | `tools/clients/slo.py` | Root |
 | [`find_similar_past_incidents`](../../sre_agent/tools/analysis/remediation/suggestions.py) | `tools/analysis/remediation/suggestions.py` | Root |
 | [`perform_causal_analysis`](../../sre_agent/tools/analysis/trace/statistical_analysis.py) | `tools/analysis/trace/statistical_analysis.py` | Root, Root Cause |

--- a/docs/architecture/system_overview.md
+++ b/docs/architecture/system_overview.md
@@ -142,7 +142,7 @@ Backend emits `{"type": "dashboard", ...}` events via `api/helpers/tool_events.p
 - [Agent Orchestration](../concepts/agent_orchestration.md): Orchestration and reasoning logic.
 - [Tools Catalog](../reference/tools.md): Catalog of analysis capabilities.
 - [Frontend](frontend.md): Flutter UI, GenUI, and Dashboard implementation.
-- [Authentication](authentication.md): IAM and Session security.
+- [Authentication](../authentication/authentication.md): IAM and Session security.
 - [Telemetry](telemetry.md): Observability and tracing architecture.
 - [Technical Decisions](decisions.md): Records of dependency constraints and implementation rationale.
 - [Multi-Agent Observability](../agent_ops/observability_theory.md): Agent Graph, AgentOps Dashboard, and self-analysis tools.

--- a/docs/authentication/auth_learnings.md
+++ b/docs/authentication/auth_learnings.md
@@ -234,8 +234,8 @@ The ID Token is preferred for identity verification because it can be validated 
 
 ## Related Documentation
 
-- [Autonomous Reliability](autonomous_reliability.md) -- Policy engine and safety layer
-- [GCP Enhancements](gcp_enhancements.md) -- Client factory pattern and EUC-aware clients
+- [Autonomous Reliability](../concepts/autonomous_reliability.md) -- Policy engine and safety layer
+- [GCP Enhancements](../concepts/gcp_enhancements.md) -- Client factory pattern and EUC-aware clients
 - [Configuration Reference](../reference/configuration.md) -- Full environment variable list
 
 ---

--- a/docs/concepts/observability.md
+++ b/docs/concepts/observability.md
@@ -241,11 +241,11 @@ The agent provides several utilities in `sre_agent/tools/common/telemetry.py` to
 
 While the sections above describe observability for **target systems** that the SRE Agent investigates, the agent itself is a complex multi-agent system that requires its own observability. The Agent Graph, AgentOps Dashboard, and Agent Self-Analysis Tools provide three complementary surfaces for understanding agent behavior:
 
-- **Agent Graph**: Aggregated topology and trajectory visualization across thousands of executions -- see [Agent Graph](agent_graph.md) for the full architecture
+- **Agent Graph**: Aggregated topology and trajectory visualization across thousands of executions -- see [Agent Graph](../agent_ops/architecture.md) for the full architecture
 - **AgentOps Dashboard**: Fleet-wide KPIs, latency charts, model/tool performance tables, and agent log streams -- see [AgentOps Dashboard Guide](../agent_ops/dashboard.md)
 - **Self-Analysis Tools**: Agent introspection for detecting anti-patterns and token waste -- see [Agent Self-Analysis](../reference/tools.md)
 
-For the complete conceptual overview, see [Multi-Agent Observability](multi_agent_observability.md).
+For the complete conceptual overview, see [Multi-Agent Observability](../agent_ops/observability_theory.md).
 
 ---
 
@@ -255,7 +255,7 @@ For the complete conceptual overview, see [Multi-Agent Observability](multi_agen
 *   [Google Cloud Trace Concepts](https://cloud.google.com/trace/docs/overview)
 *   [Google SRE Book - Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/)
 *   [Langfuse - OpenTelemetry Integration](https://langfuse.com/integrations/native/opentelemetry)
-*   [Multi-Agent Observability](multi_agent_observability.md) -- How the three observability surfaces work together
+*   [Multi-Agent Observability](../agent_ops/observability_theory.md) -- How the three observability surfaces work together
 *   [AgentOps Dashboard Guide](../agent_ops/dashboard.md) -- Operational monitoring with KPIs and charts
 *   [Memory Best Practices](memory.md) -- Memory event visibility system
 *   [Agent Orchestration](agent_orchestration.md) -- Council activity graph for frontend

--- a/docs/concepts/online_research_and_self_healing.md
+++ b/docs/concepts/online_research_and_self_healing.md
@@ -151,7 +151,7 @@ The Auto SRE agent should be able to **observe its own behavior, diagnose issues
 
 ### The OODA Self-Healing Loop
 
-This architecture follows the [OODA loop](docs/concepts/autonomous_reliability.md) already established in the project, applied to the agent itself:
+This architecture follows the [OODA loop](autonomous_reliability.md) already established in the project, applied to the agent itself:
 
 ```
 ┌─────────────────────────────────────────────────────────────┐

--- a/docs/debugging/debugging_genui.md
+++ b/docs/debugging/debugging_genui.md
@@ -1,6 +1,6 @@
 # Debugging the GenUI/A2UI Protocol
 
-This guide documents known issues and debugging techniques for the GenUI (A2UI) protocol implementation in the Auto SRE Agent. For a comprehensive overview of the architecture and component schemas, see **[Rendering Telemetry](rendering_telemetry.md)**.
+This guide documents known issues and debugging techniques for the GenUI (A2UI) protocol implementation in the Auto SRE Agent. For a comprehensive overview of the architecture and component schemas, see **[Rendering Telemetry](../guides/rendering_telemetry.md)**.
 
 ## A2UI v0.8 Protocol Compliance
 

--- a/docs/guides/default_experience.md
+++ b/docs/guides/default_experience.md
@@ -365,7 +365,7 @@ _onProjectChanged() [conversation_page.dart]
 
 ## Related Documentation
 
-- [Dashboard UI](dashboard_ui.md) -- Full Observability Explorer reference
+- [Dashboard UI](dashboard_query_language.md) -- Full Observability Explorer reference
 - [Project Selector](project_selector.md) -- Project selection implementation details
 - [Rendering Telemetry](rendering_telemetry.md) -- GenUI/A2UI widget schemas and data flow
-- [Debugging Telemetry & Auth](debugging_telemetry_and_auth.md) -- Troubleshooting missing data
+- [Debugging Telemetry & Auth](../debugging/debugging_telemetry_and_auth.md) -- Troubleshooting missing data

--- a/docs/guides/development.md
+++ b/docs/guides/development.md
@@ -182,7 +182,7 @@ Tools live in `sre_agent/tools/` (158+ files). Key conventions:
     *   `SRE_AGENT_DEPLOYMENT_MODE=true`
 *   **Naming**: `test_<function>_<condition>_<expected>` (e.g., `test_fetch_trace_not_found_returns_error`).
 
-See [Testing Guide](testing.md) for comprehensive details.
+See [Testing Guide](../testing/testing.md) for comprehensive details.
 
 ---
 

--- a/docs/guides/getting_started.md
+++ b/docs/guides/getting_started.md
@@ -223,8 +223,8 @@ See [Deployment Guide](deployment.md) for detailed production instructions.
 ## Next Steps
 
 *   [Development Guide](development.md) -- Development workflow, coding standards, and PR checklist.
-*   [Linting Guide](linting.md) -- Linting tools, configuration, and enforcement rules.
-*   [Testing Guide](testing.md) -- Test conventions, coverage requirements, and how to run tests.
+*   [Linting Guide](../testing/linting.md) -- Linting tools, configuration, and enforcement rules.
+*   [Testing Guide](../testing/testing.md) -- Test conventions, coverage requirements, and how to run tests.
 *   [Deployment Guide](deployment.md) -- Production deployment instructions.
 
 ---

--- a/docs/guides/rendering_telemetry.md
+++ b/docs/guides/rendering_telemetry.md
@@ -502,7 +502,7 @@ If the component should also appear in the Observability Explorer:
 
 ## Debugging
 
-See [Debugging GenUI](debugging_genui.md) for detailed instructions on how to inspect the event stream and trace rendering issues.
+See [Debugging GenUI](../debugging/debugging_genui.md) for detailed instructions on how to inspect the event stream and trace rendering issues.
 
 Common debugging steps:
 1. Check the browser DevTools Network tab for SSE events.

--- a/docs/testing/testing.md
+++ b/docs/testing/testing.md
@@ -20,7 +20,7 @@ Our philosophy is simple: **If it is not tested, it is broken.**
 
 ## Test Suite Overview
 
-As of 2026-02-15, the project has **196 Python test files** containing approximately **2,429+ test functions** and **21 Flutter test files** containing approximately **129 test functions**.
+As of 2026-04-04, the project has **239 Python test files** and **41 Flutter test files**.
 
 ---
 
@@ -54,7 +54,7 @@ We use `gemini-1.5-pro` to grade responses on:
 * **Root Cause Causality**: "Why" it happened vs just "What" happened.
 * **Actionability**: Clear, recommended shell commands or fixes.
 
-For implementation details, see **[docs/../EVALUATIONS.md](evaluation.md)**.
+For implementation details, see **[docs/EVALUATIONS.md](../EVALUATIONS.md)**.
 
 ---
 

--- a/llm.txt
+++ b/llm.txt
@@ -7,7 +7,7 @@ Auto SRE is an AI-powered Site Reliability Engineering agent that automates
 incident investigation on Google Cloud Platform using a "Council of Experts"
 pattern — specialized sub-agents for traces, logs, metrics, alerts, and root cause.
 
-Version: 0.2.0 | License: Apache-2.0 | Status: Phase 3 active (2277+ backend tests, 129 Flutter tests)
+Version: 0.2.0 | License: Apache-2.0 | Status: Phase 3 active (239 Python test files, 41 Flutter test files)
 
 ## TECH STACK
 - Backend: Python 3.10+ (<3.13), FastAPI, Google ADK 1.23.0, Pydantic 2

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,9 +1,9 @@
 # SRE Agent Test Suite
 
-This directory contains the Python test suite for the SRE Agent. As of 2026-02-15, the suite includes **196 test files** containing approximately **2,300+ test functions** with an 80% minimum coverage gate.
+This directory contains the Python test suite for the SRE Agent. As of 2026-04-04, the suite includes **239 Python test files** with an 80% minimum coverage gate.
 
 For the full testing strategy and style guide, see [docs/testing/testing.md](../docs/testing/testing.md).
-For Flutter frontend tests, see [docs/guides/frontend_testing.md](../docs/guides/frontend_testing.md).
+For Flutter frontend tests, see [docs/testing/frontend_testing.md](../docs/testing/frontend_testing.md).
 
 ## Directory Structure
 


### PR DESCRIPTION
### Motivation
- Repair numerous broken or stale cross-references and path imports introduced by doc reorganization. 
- Bring documentation metadata (test counts, badges) up to date with the current test suite. 
- Reflect recent code refactors by correcting tool/module paths referenced in the architecture and tooling inventory. 

### Description
- Updated top-level `README.md` test badge and several high-level docs to show the new test file counts and frontend/backend breakdown. 
- Normalized and corrected relative links across many files (examples: `agent_graph.md` -> `architecture.md`, `multi_agent_observability.md` -> `observability_theory.md`, and multiple `../` path fixes) to match the reorganized docs tree. 
- Fixed tool path references in `docs/architecture/AGENTS_AND_TOOLS.md` (moved `list_gcp_projects`, `list_error_events`, and `get_current_time` entries to their new module locations). 
- Updated multiple README and guide files (`autosre/README.md`, `docs/*`) to reflect UI state management changes and new troubleshooting/reference paths. 

### Testing
- This is a documentation-only change and the codebase behavior was not modified. 
- Ran the repository checks: `uv run poe lint-all` completed without errors. 
- Ran the Python test suite via `uv run poe test` and the CI tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69d09ebff8f883259bee85eeb918895e)