### PR TITLE
⚡ Bolt: Offload synchronous OAuth2 token verification

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+
+## 2025-02-18 - Offloading Synchronous OAuth2 Token Verification
+**Learning:** `google.oauth2.id_token.verify_oauth2_token` is a synchronous operation that can block the FastAPI event loop, especially when fetching public keys.
+**Action:** Always offload synchronous auth library calls using `fastapi.concurrency.run_in_threadpool` in async endpoints to maintain application responsiveness.

--- a/sre_agent/auth.py
+++ b/sre_agent/auth.py
@@ -857,6 +857,7 @@ async def validate_id_token(id_token_str: str) -> TokenInfo:
     if cached:
         return cached
 
+    from fastapi.concurrency import run_in_threadpool
     from google.auth.transport import requests
 
     try:
@@ -866,7 +867,9 @@ async def validate_id_token(id_token_str: str) -> TokenInfo:
         # Local signature verification and claim extraction
         # SECURITY: Specifying audience (GOOGLE_CLIENT_ID) prevents ID token substitution attacks
         client_id = os.environ.get("GOOGLE_CLIENT_ID")
-        idinfo = id_token.verify_oauth2_token(id_token_str, request, audience=client_id)  # type: ignore[no-untyped-call]
+        idinfo = await run_in_threadpool(
+            id_token.verify_oauth2_token, id_token_str, request, audience=client_id
+        )
 
         info = TokenInfo(
             valid=True,


### PR DESCRIPTION
💡 What: Wrapped `id_token.verify_oauth2_token` in `fastapi.concurrency.run_in_threadpool`.
🎯 Why: To prevent blocking the FastAPI async event loop during synchronous public key fetching and signature verification.
📊 Impact: Improves concurrency and unblocks the main thread for other requests during token verification.
🔬 Measurement: Monitor event loop delay metrics under high authentication load.

---
*PR created automatically by Jules for task [13775854495983899947](https://jules.google.com/task/13775854495983899947) started by @srtux*