### PR TITLE
⚡ Bolt: Offload blocking verify_oauth2_token to threadpool

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+
+## 2025-02-19 - [Offload verify_oauth2_token to Threadpool]
+**Learning:** `google.oauth2.id_token.verify_oauth2_token` is a synchronous, blocking function that can fetch public keys over the network or perform CPU-intensive cryptography. Calling it directly inside an `async def` FastAPI handler or middleware blocks the event loop, degrading concurrent request performance.
+**Action:** Always wrap synchronous blocking I/O or CPU-bound calls from the `google-auth` library inside `await fastapi.concurrency.run_in_threadpool` in async contexts.

--- a/sre_agent/auth.py
+++ b/sre_agent/auth.py
@@ -81,6 +81,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, cast
 
 import google.auth
+from fastapi.concurrency import run_in_threadpool
 from google.oauth2 import id_token
 from google.oauth2.credentials import Credentials
 
@@ -866,7 +867,9 @@ async def validate_id_token(id_token_str: str) -> TokenInfo:
         # Local signature verification and claim extraction
         # SECURITY: Specifying audience (GOOGLE_CLIENT_ID) prevents ID token substitution attacks
         client_id = os.environ.get("GOOGLE_CLIENT_ID")
-        idinfo = id_token.verify_oauth2_token(id_token_str, request, audience=client_id)  # type: ignore[no-untyped-call]
+        idinfo = await run_in_threadpool(
+            id_token.verify_oauth2_token, id_token_str, request, audience=client_id
+        )
 
         info = TokenInfo(
             valid=True,


### PR DESCRIPTION
💡 What: Wrapped `id_token.verify_oauth2_token` in `fastapi.concurrency.run_in_threadpool` in `sre_agent/auth.py`.
🎯 Why: `verify_oauth2_token` is a synchronous, blocking call. Calling it directly inside an async function blocks the event loop, impacting concurrent request handling.
📊 Impact: Prevents event loop blocking, significantly improving throughput and concurrent request performance when multiple authentications happen.
🔬 Measurement: Observe endpoint latency (e.g. any endpoint relying on `validate_id_token`) under concurrent load. The event loop should no longer pause when validating tokens.

---
*PR created automatically by Jules for task [2949335153755020908](https://jules.google.com/task/2949335153755020908) started by @srtux*