### PR TITLE
⚡ Bolt: [performance improvement] Parallelize component health checks

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+
+## 2025-02-18 - [Parallelize Log Queries in App Telemetry]
+**Learning:** `get_application_health` was performing sequential `run_in_threadpool` API calls inside a loop to gather component errors for Cloud Run and GKE. This causes an N+1 latency bottleneck as the number of components increases.
+**Action:** Extract the concurrent API calls into a list and use `asyncio.gather(*tasks)` to run them all in parallel before iterating through the results to map back to components. This reduces latency significantly.

--- a/sre_agent/tools/clients/app_telemetry.py
+++ b/sre_agent/tools/clients/app_telemetry.py
@@ -12,6 +12,7 @@ It enables the SRE agent to:
 Reference: https://cloud.google.com/app-hub/docs/overview
 """
 
+import asyncio
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -517,7 +518,10 @@ async def get_application_health(
         "components": [],
     }
 
-    # Check each Cloud Run service
+    cloud_run_components = []
+    log_tasks = []
+
+    # Prepare Cloud Run service checks
     for svc in resources.get("cloud_run_services", []):
         service_name = svc.get("service", "")
         location_name = svc.get("location", "")
@@ -531,6 +535,7 @@ async def get_application_health(
             "status": "HEALTHY",
             "issues": [],
         }
+        cloud_run_components.append(component_health)
 
         # Check for recent errors
         error_filter = (
@@ -538,28 +543,21 @@ async def get_application_health(
             f'resource.labels.service_name="{service_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+        log_tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
 
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(
-                    f"Cloud Run {service_name}: {error_count} errors"
-                )
-
-        health["components"].append(component_health)
-
-    # Check GKE clusters
+    gke_components = []
     seen_clusters: set[str] = set()
+
+    # Prepare GKE cluster checks
     for cluster in resources.get("gke_clusters", []):
         cluster_name = cluster.get("cluster", "")
         if not cluster_name or cluster_name in seen_clusters:
@@ -572,6 +570,7 @@ async def get_application_health(
             "status": "HEALTHY",
             "issues": [],
         }
+        gke_components.append(component_health)
 
         # Check for pod errors
         error_filter = (
@@ -579,22 +578,49 @@ async def get_application_health(
             f'resource.labels.cluster_name="{cluster_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+        log_tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
+
+    # Execute all log queries in parallel
+    log_results = await asyncio.gather(*log_tasks) if log_tasks else []
+
+    # Process Cloud Run results
+    result_idx = 0
+    for component_health in cloud_run_components:
+        errors = log_results[result_idx]
+        result_idx += 1
 
         if isinstance(errors, dict) and "entries" in errors:
             error_count = len(errors.get("entries", []))
             if error_count > 0:
                 component_health["status"] = "DEGRADED"
                 component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(f"GKE {cluster_name}: {error_count} errors")
+                health["issues"].append(
+                    f"Cloud Run {component_health['name']}: {error_count} errors"
+                )
+        health["components"].append(component_health)
 
+    # Process GKE results
+    for component_health in gke_components:
+        errors = log_results[result_idx]
+        result_idx += 1
+
+        if isinstance(errors, dict) and "entries" in errors:
+            error_count = len(errors.get("entries", []))
+            if error_count > 0:
+                component_health["status"] = "DEGRADED"
+                component_health["issues"].append(f"{error_count} recent errors")
+                health["issues"].append(
+                    f"GKE {component_health['name']}: {error_count} errors"
+                )
         health["components"].append(component_health)
 
     # Check Cloud SQL instances


### PR DESCRIPTION
💡 **What**: Refactored the `get_application_health` function in `app_telemetry.py` to launch its component log queries concurrently. All tasks are collected into a list and executed via `asyncio.gather` rather than waiting for each API call sequentially in a loop.
🎯 **Why**: Previously, there was an N+1 latency bottleneck where each component (Cloud Run service and GKE cluster) queried its logs sequentially. As the number of components increased, execution time scaled linearly and caused significant delays.
📊 **Impact**: Expected latency reduction is roughly proportional to the number of components evaluated. The function now evaluates all components in roughly the time of a single component check.
🔬 **Measurement**: Run the `get_application_health` tool on a large topology and verify that trace spans for log entries are concurrent rather than sequential.

---
*PR created automatically by Jules for task [4875623222041894697](https://jules.google.com/task/4875623222041894697) started by @srtux*