### PR TITLE
⚡ Bolt: [performance improvement] Optimize AppHub telemetry sequential querying using asyncio.gather

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+## 2024-06-07 - [App Telemetry Latency Bottlenecks]
+**Learning:** In the `sre_agent/tools/clients/app_telemetry.py` file, querying lists of resources using `await run_in_threadpool(...)` in sequential `for` loops across components like Cloud Run and GKE triggers significant N+1 API call latency.
+**Action:** Always inspect sequential `for` loops iterating over application or cloud resources inside `async` API route logic. Gather independent API tasks into a list and await them concurrently with `asyncio.gather(*tasks)` to resolve network I/O in parallel, optimizing execution time.

--- a/sre_agent/tools/clients/app_telemetry.py
+++ b/sre_agent/tools/clients/app_telemetry.py
@@ -304,16 +304,23 @@ async def get_application_metrics(
         "components": [],
     }
 
-    for resource_filter in metric_filters:
+    import asyncio
+
+    async def fetch_metric(resource_filter: str) -> tuple[str, Any]:
         full_filter = f'metric.type="{metric_type}" AND {resource_filter}'
-        metric_data = await run_in_threadpool(
+        data = await run_in_threadpool(
             _list_time_series_sync,
             project_id,
             full_filter,
             minutes_ago,
             tool_context,
         )
+        return resource_filter, data
 
+    tasks = [fetch_metric(rf) for rf in metric_filters]
+    metric_results = await asyncio.gather(*tasks)
+
+    for resource_filter, metric_data in metric_results:
         if isinstance(metric_data, list):
             results["components"].append(
                 {
@@ -517,12 +524,13 @@ async def get_application_health(
         "components": [],
     }
 
-    # Check each Cloud Run service
-    for svc in resources.get("cloud_run_services", []):
+    import asyncio
+
+    async def check_cloud_run(svc: dict[str, Any]) -> dict[str, Any] | None:
         service_name = svc.get("service", "")
         location_name = svc.get("location", "")
         if not service_name:
-            continue
+            return None
 
         component_health: dict[str, Any] = {
             "type": "cloud_run",
@@ -532,7 +540,6 @@ async def get_application_health(
             "issues": [],
         }
 
-        # Check for recent errors
         error_filter = (
             f'resource.type="cloud_run_revision" AND '
             f'resource.labels.service_name="{service_name}" AND '
@@ -547,33 +554,34 @@ async def get_application_health(
             tool_context,
         )
 
+        error_count = 0
         if isinstance(errors, dict) and "entries" in errors:
             error_count = len(errors.get("entries", []))
             if error_count > 0:
                 component_health["status"] = "DEGRADED"
                 component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(
-                    f"Cloud Run {service_name}: {error_count} errors"
-                )
 
-        health["components"].append(component_health)
+        return {
+            "component_health": component_health,
+            "service_name": service_name,
+            "error_count": error_count,
+        }
 
-    # Check GKE clusters
-    seen_clusters: set[str] = set()
-    for cluster in resources.get("gke_clusters", []):
+    async def check_gke(
+        cluster: dict[str, Any], seen: set[str]
+    ) -> dict[str, Any] | None:
         cluster_name = cluster.get("cluster", "")
-        if not cluster_name or cluster_name in seen_clusters:
-            continue
-        seen_clusters.add(cluster_name)
+        if not cluster_name or cluster_name in seen:
+            return None
+        seen.add(cluster_name)
 
-        component_health = {
+        component_health: dict[str, Any] = {
             "type": "gke_cluster",
             "name": cluster_name,
             "status": "HEALTHY",
             "issues": [],
         }
 
-        # Check for pod errors
         error_filter = (
             f'resource.type="k8s_container" AND '
             f'resource.labels.cluster_name="{cluster_name}" AND '
@@ -588,14 +596,47 @@ async def get_application_health(
             tool_context,
         )
 
+        error_count = 0
         if isinstance(errors, dict) and "entries" in errors:
             error_count = len(errors.get("entries", []))
             if error_count > 0:
                 component_health["status"] = "DEGRADED"
                 component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(f"GKE {cluster_name}: {error_count} errors")
 
-        health["components"].append(component_health)
+        return {
+            "component_health": component_health,
+            "cluster_name": cluster_name,
+            "error_count": error_count,
+        }
+
+    seen_clusters: set[str] = set()
+
+    cloud_run_tasks = [
+        check_cloud_run(svc) for svc in resources.get("cloud_run_services", [])
+    ]
+    gke_tasks = [
+        check_gke(cluster, seen_clusters)
+        for cluster in resources.get("gke_clusters", [])
+    ]
+
+    all_results = await asyncio.gather(*(cloud_run_tasks + gke_tasks))
+
+    for res in all_results:
+        if res is None:
+            continue
+
+        comp_health = res["component_health"]
+        health["components"].append(comp_health)
+
+        if res["error_count"] > 0:
+            if comp_health["type"] == "cloud_run":
+                health["issues"].append(
+                    f"Cloud Run {res['service_name']}: {res['error_count']} errors"
+                )
+            elif comp_health["type"] == "gke_cluster":
+                health["issues"].append(
+                    f"GKE {res['cluster_name']}: {res['error_count']} errors"
+                )
 
     # Check Cloud SQL instances
     for sql in resources.get("cloud_sql_instances", []):


### PR DESCRIPTION
💡 **What**: Refactored the metric and log-fetching logic inside `sre_agent/tools/clients/app_telemetry.py`. Replaced sequential `await run_in_threadpool(...)` loops within `get_application_metrics` and `get_application_health` (for Cloud Run services and GKE clusters) with inner async functions, executing the tasks concurrently via `asyncio.gather(*tasks)`.

🎯 **Why**: Previously, these functions queried each component resource iteratively, blocking execution on every individual API call. This created a significant N+1 latency bottleneck as applications scale with more microservices and clusters.

📊 **Impact**: Executing the network I/O calls concurrently dramatically reduces the total time spent waiting on Google Cloud operations, eliminating the N+1 API bottleneck when retrieving unified application health metrics and logs.

🔬 **Measurement**: Verify by benchmarking the tool response time for a multi-service AppHub application before and after these changes; the latency should decrease substantially, scaling at O(1) latency relative to the slowest external response rather than O(N) relative to the number of components.

---
*PR created automatically by Jules for task [2865752686068051988](https://jules.google.com/task/2865752686068051988) started by @srtux*