### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+
+## 2024-05-18 - [FastAPI Threadpool Asyncio Gather]
+**Learning:** In FastAPI/FastAPI.concurrency, when executing identical `run_in_threadpool` independent API or backend calls dynamically inside loops (like verifying multiple components' health log queries concurrently), utilizing sequential loop awaits causes an N+1 latency bottleneck blocking tasks.
+**Action:** Always collect sequential un-dependent `run_in_threadpool` wrapped API query tasks in lists across loop logic components first, and then execute all elements together using `asyncio.gather(*all_tasks)` to execute the sync threads concurrently preventing large latency spikes in unified aggregation tool responses.

--- a/sre_agent/tools/clients/app_telemetry.py
+++ b/sre_agent/tools/clients/app_telemetry.py
@@ -474,6 +474,8 @@ async def get_application_health(
     Example:
         get_application_health("my-app")
     """
+    import asyncio
+
     from fastapi.concurrency import run_in_threadpool
 
     from .logging import _list_log_entries_sync
@@ -517,6 +519,10 @@ async def get_application_health(
         "components": [],
     }
 
+    # Initialize lists to gather tasks for concurrent execution
+    cloud_run_components = []
+    cloud_run_tasks = []
+
     # Check each Cloud Run service
     for svc in resources.get("cloud_run_services", []):
         service_name = svc.get("service", "")
@@ -538,26 +544,21 @@ async def get_application_health(
             f'resource.labels.service_name="{service_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+
+        cloud_run_components.append(component_health)
+        cloud_run_tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
 
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(
-                    f"Cloud Run {service_name}: {error_count} errors"
-                )
-
-        health["components"].append(component_health)
-
+    gke_components = []
+    gke_tasks = []
     # Check GKE clusters
     seen_clusters: set[str] = set()
     for cluster in resources.get("gke_clusters", []):
@@ -579,14 +580,45 @@ async def get_application_health(
             f'resource.labels.cluster_name="{cluster_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+
+        gke_components.append(component_health)
+        gke_tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
+
+    # ⚡ Bolt Optimization: Gather all independent log queries and execute them concurrently
+    # This prevents N+1 latency bottlenecks when checking multiple components.
+    all_tasks = cloud_run_tasks + gke_tasks
+    results = await asyncio.gather(*all_tasks) if all_tasks else []
+
+    # Process Cloud Run results
+    for i, component_health in enumerate(cloud_run_components):
+        service_name = component_health["name"]
+        errors = results[i]
+
+        if isinstance(errors, dict) and "entries" in errors:
+            error_count = len(errors.get("entries", []))
+            if error_count > 0:
+                component_health["status"] = "DEGRADED"
+                component_health["issues"].append(f"{error_count} recent errors")
+                health["issues"].append(
+                    f"Cloud Run {service_name}: {error_count} errors"
+                )
+
+        health["components"].append(component_health)
+
+    # Process GKE results
+    offset = len(cloud_run_tasks)
+    for i, component_health in enumerate(gke_components):
+        cluster_name = component_health["name"]
+        errors = results[offset + i]
 
         if isinstance(errors, dict) and "entries" in errors:
             error_count = len(errors.get("entries", []))


### PR DESCRIPTION
💡 What: Refactored `get_application_health` in `sre_agent/tools/clients/app_telemetry.py` to batch independent `run_in_threadpool` log query tasks for Cloud Run and GKE components. Used `asyncio.gather` to execute them concurrently instead of sequentially iterating through components.
🎯 Why: Iterating over components and awaiting log fetches sequentially created an N+1 query latency bottleneck (where an app with 5 services would pause 5 times).
📊 Impact: Expected ~30-70% response time reduction for applications with multiple cloud run or GKE components.
🔬 Measurement: Latency benchmarks of `get_application_health` against topologies with 5+ components.

---
*PR created automatically by Jules for task [6888529230818219403](https://jules.google.com/task/6888529230818219403) started by @srtux*