### PR TITLE
⚡ Bolt: [performance improvement] Eliminate N+1 loop bottlenecks in App Telemetry queries

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+## 2024-05-20 - Eliminating N+1 Bottlenecks in Async Topology Queries
+**Learning:** Sequential `run_in_threadpool` executions inside loops (like iterating through cloud_run_services or gke_clusters) introduce severe N+1 latency bottlenecks. Since the underlying operations involve synchronous I/O blocks, running them one by one blocks the completion of the aggregate tool call unnecessarily.
+**Action:** Always batch these tasks into a list and execute them concurrently using `asyncio.gather`. Also ensure we use `strict=True` on `zip()` when matching the results back to the objects to adhere to codebase style standards (B905).

--- a/sre_agent/tools/clients/app_telemetry.py
+++ b/sre_agent/tools/clients/app_telemetry.py
@@ -12,6 +12,7 @@ It enables the SRE agent to:
 Reference: https://cloud.google.com/app-hub/docs/overview
 """
 
+import asyncio
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -304,16 +305,27 @@ async def get_application_metrics(
         "components": [],
     }
 
+    # Build tasks for concurrent execution
+    tasks = []
     for resource_filter in metric_filters:
         full_filter = f'metric.type="{metric_type}" AND {resource_filter}'
-        metric_data = await run_in_threadpool(
-            _list_time_series_sync,
-            project_id,
-            full_filter,
-            minutes_ago,
-            tool_context,
+        tasks.append(
+            run_in_threadpool(
+                _list_time_series_sync,
+                project_id,
+                full_filter,
+                minutes_ago,
+                tool_context,
+            )
         )
 
+    # Execute all queries concurrently
+    metric_data_results = await asyncio.gather(*tasks)
+
+    # Process results
+    for resource_filter, metric_data in zip(
+        metric_filters, metric_data_results, strict=True
+    ):
         if isinstance(metric_data, list):
             results["components"].append(
                 {
@@ -518,84 +530,111 @@ async def get_application_health(
     }
 
     # Check each Cloud Run service
+    valid_cloud_run_services = []
+    cloud_run_tasks = []
+
     for svc in resources.get("cloud_run_services", []):
         service_name = svc.get("service", "")
-        location_name = svc.get("location", "")
         if not service_name:
             continue
 
-        component_health: dict[str, Any] = {
-            "type": "cloud_run",
-            "name": service_name,
-            "location": location_name,
-            "status": "HEALTHY",
-            "issues": [],
-        }
+        valid_cloud_run_services.append(svc)
 
-        # Check for recent errors
+        # Build query for recent errors
         error_filter = (
             f'resource.type="cloud_run_revision" AND '
             f'resource.labels.service_name="{service_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+        cloud_run_tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
 
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(
-                    f"Cloud Run {service_name}: {error_count} errors"
-                )
+    if cloud_run_tasks:
+        cloud_run_errors_results = await asyncio.gather(*cloud_run_tasks)
 
-        health["components"].append(component_health)
+        for svc, errors in zip(
+            valid_cloud_run_services, cloud_run_errors_results, strict=True
+        ):
+            service_name = svc.get("service", "")
+            location_name = svc.get("location", "")
+
+            c_health: dict[str, Any] = {
+                "type": "cloud_run",
+                "name": service_name,
+                "location": location_name,
+                "status": "HEALTHY",
+                "issues": [],
+            }
+
+            if isinstance(errors, dict) and "entries" in errors:
+                error_count = len(errors.get("entries", []))
+                if error_count > 0:
+                    c_health["status"] = "DEGRADED"
+                    c_health["issues"].append(f"{error_count} recent errors")
+                    health["issues"].append(
+                        f"Cloud Run {service_name}: {error_count} errors"
+                    )
+
+            health["components"].append(c_health)
 
     # Check GKE clusters
     seen_clusters: set[str] = set()
+    valid_gke_clusters = []
+    gke_tasks = []
+
     for cluster in resources.get("gke_clusters", []):
         cluster_name = cluster.get("cluster", "")
         if not cluster_name or cluster_name in seen_clusters:
             continue
         seen_clusters.add(cluster_name)
+        valid_gke_clusters.append(cluster_name)
 
-        component_health = {
-            "type": "gke_cluster",
-            "name": cluster_name,
-            "status": "HEALTHY",
-            "issues": [],
-        }
-
-        # Check for pod errors
+        # Build query for pod errors
         error_filter = (
             f'resource.type="k8s_container" AND '
             f'resource.labels.cluster_name="{cluster_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+        gke_tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
 
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(f"GKE {cluster_name}: {error_count} errors")
+    if gke_tasks:
+        gke_errors_results = await asyncio.gather(*gke_tasks)
 
-        health["components"].append(component_health)
+        for cluster_name, errors in zip(
+            valid_gke_clusters, gke_errors_results, strict=True
+        ):
+            c_health = {
+                "type": "gke_cluster",
+                "name": cluster_name,
+                "status": "HEALTHY",
+                "issues": [],
+            }
+
+            if isinstance(errors, dict) and "entries" in errors:
+                error_count = len(errors.get("entries", []))
+                if error_count > 0:
+                    c_health["status"] = "DEGRADED"
+                    c_health["issues"].append(f"{error_count} recent errors")
+                    health["issues"].append(f"GKE {cluster_name}: {error_count} errors")
+
+            health["components"].append(c_health)
 
     # Check Cloud SQL instances
     for sql in resources.get("cloud_sql_instances", []):


### PR DESCRIPTION
💡 What:
Refactored the application topology query loops inside `sre_agent/tools/clients/app_telemetry.py` (`get_application_metrics` and `get_application_health`). Replaced sequential `await run_in_threadpool()` executions loops with concurrent list aggregation utilizing `asyncio.gather()`.

🎯 Why:
The sequential iterations block the asynchronous event loop on synchronous I/O. When a topology contains several services or clusters, querying for individual metrics/logs sequentially introduces severe N+1 latency bottlenecks across the whole system. By utilizing `asyncio.gather`, all data queries for every cloud run service, gke cluster, and apphub resource are effectively executed simultaneously. 

📊 Impact:
Significantly reduces query times for complex Application topologies, bounded primarily by the latency of the slowest independent database or logging API call rather than the cumulative latency of every single service. This makes the `get_application_health` and `get_application_metrics` tools noticeably snappier for the LLM.

🔬 Measurement:
1. Initialize a large Application Hub topology containing dozens of Cloud Run services or GKE clusters.
2. Run `get_application_health` and observe the response time. The aggregate result should arrive significantly faster than observing individual sequential logs being resolved in BigQuery/Cloud Logging.

---
*PR created automatically by Jules for task [237592086433347802](https://jules.google.com/task/237592086433347802) started by @srtux*