### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+
+## 2025-06-20 - [Parallelize Log Queries in get_application_health]
+**Learning:** The get_application_health tool performed sequential N+1 log queries for errors in each cloud run service and GKE cluster. These queries are independent and block the asynchronous event loop sequentially.
+**Action:** Replaced sequential awaits in loops with a list of tasks, executing them concurrently using asyncio.gather to eliminate the N+1 latency bottleneck.

--- a/sre_agent/tools/clients/app_telemetry.py
+++ b/sre_agent/tools/clients/app_telemetry.py
@@ -474,6 +474,8 @@ async def get_application_health(
     Example:
         get_application_health("my-app")
     """
+    import asyncio
+
     from fastapi.concurrency import run_in_threadpool
 
     from .logging import _list_log_entries_sync
@@ -517,6 +519,9 @@ async def get_application_health(
         "components": [],
     }
 
+    tasks = []
+    components_info = []
+
     # Check each Cloud Run service
     for svc in resources.get("cloud_run_services", []):
         service_name = svc.get("service", "")
@@ -524,7 +529,7 @@ async def get_application_health(
         if not service_name:
             continue
 
-        component_health: dict[str, Any] = {
+        c_health: dict[str, Any] = {
             "type": "cloud_run",
             "name": service_name,
             "location": location_name,
@@ -538,7 +543,7 @@ async def get_application_health(
             f'resource.labels.service_name="{service_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
+        task = run_in_threadpool(
             _list_log_entries_sync,
             project_id,
             error_filter,
@@ -546,17 +551,8 @@ async def get_application_health(
             None,
             tool_context,
         )
-
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(
-                    f"Cloud Run {service_name}: {error_count} errors"
-                )
-
-        health["components"].append(component_health)
+        tasks.append(task)
+        components_info.append(c_health)
 
     # Check GKE clusters
     seen_clusters: set[str] = set()
@@ -566,7 +562,7 @@ async def get_application_health(
             continue
         seen_clusters.add(cluster_name)
 
-        component_health = {
+        g_health: dict[str, Any] = {
             "type": "gke_cluster",
             "name": cluster_name,
             "status": "HEALTHY",
@@ -579,7 +575,7 @@ async def get_application_health(
             f'resource.labels.cluster_name="{cluster_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
+        task = run_in_threadpool(
             _list_log_entries_sync,
             project_id,
             error_filter,
@@ -587,15 +583,29 @@ async def get_application_health(
             None,
             tool_context,
         )
+        tasks.append(task)
+        components_info.append(g_health)
 
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(f"GKE {cluster_name}: {error_count} errors")
+    # Execute all independent error log queries concurrently
+    if tasks:
+        results = await asyncio.gather(*tasks)
+        for comp_health, errors in zip(components_info, results, strict=True):
+            if isinstance(errors, dict) and "entries" in errors:
+                error_count = len(errors.get("entries", []))
+                if error_count > 0:
+                    comp_health["status"] = "DEGRADED"
+                    comp_health["issues"].append(f"{error_count} recent errors")
 
-        health["components"].append(component_health)
+                    if comp_health["type"] == "cloud_run":
+                        health["issues"].append(
+                            f"Cloud Run {comp_health['name']}: {error_count} errors"
+                        )
+                    elif comp_health["type"] == "gke_cluster":
+                        health["issues"].append(
+                            f"GKE {comp_health['name']}: {error_count} errors"
+                        )
+
+            health["components"].append(comp_health)
 
     # Check Cloud SQL instances
     for sql in resources.get("cloud_sql_instances", []):


### PR DESCRIPTION
💡 What: Refactored `get_application_health` to use `asyncio.gather` for independent error log queries across Cloud Run services and GKE clusters.
🎯 Why: To solve an N+1 query performance bottleneck where independent log searches were awaited sequentially inside loops.
📊 Impact: significantly reduces the execution time of retrieving application health when many components exist by parallelizing the network I/O.
🔬 Measurement: Verify the improvement by running the tests and observing faster `get_application_health` execution for complex topologies.

---
*PR created automatically by Jules for task [16011613915497550787](https://jules.google.com/task/16011613915497550787) started by @srtux*