### PR TITLE
⚡ Bolt: [performance improvement] Parallelize log queries in get_application_health

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+
+## 2025-02-18 - [Parallelize N+1 Log Queries in AppHub Health]
+**Learning:** Functions like `get_application_health` often loop through topology components (like Cloud Run services and GKE clusters) and sequentially make `run_in_threadpool` external logging queries for each component. This results in an N+1 query bottleneck, causing overall latency to increase linearly with the number of components.
+**Action:** Always accumulate `run_in_threadpool` or direct async calls for independent resources into a list of tasks and use `asyncio.gather` to execute them concurrently, reducing total execution time to the duration of the slowest single request.

--- a/sre_agent/tools/clients/app_telemetry.py
+++ b/sre_agent/tools/clients/app_telemetry.py
@@ -474,6 +474,8 @@ async def get_application_health(
     Example:
         get_application_health("my-app")
     """
+    import asyncio
+
     from fastapi.concurrency import run_in_threadpool
 
     from .logging import _list_log_entries_sync
@@ -517,7 +519,11 @@ async def get_application_health(
         "components": [],
     }
 
-    # Check each Cloud Run service
+    # Parallelize log queries
+    tasks = []
+    task_metadata = []
+
+    # Prepare Cloud Run tasks
     for svc in resources.get("cloud_run_services", []):
         service_name = svc.get("service", "")
         location_name = svc.get("location", "")
@@ -532,33 +538,25 @@ async def get_application_health(
             "issues": [],
         }
 
-        # Check for recent errors
         error_filter = (
             f'resource.type="cloud_run_revision" AND '
             f'resource.labels.service_name="{service_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+
+        tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
+        task_metadata.append(component_health)
 
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(
-                    f"Cloud Run {service_name}: {error_count} errors"
-                )
-
-        health["components"].append(component_health)
-
-    # Check GKE clusters
+    # Prepare GKE tasks
     seen_clusters: set[str] = set()
     for cluster in resources.get("gke_clusters", []):
         cluster_name = cluster.get("cluster", "")
@@ -573,29 +571,47 @@ async def get_application_health(
             "issues": [],
         }
 
-        # Check for pod errors
         error_filter = (
             f'resource.type="k8s_container" AND '
             f'resource.labels.cluster_name="{cluster_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+
+        tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
+        task_metadata.append(component_health)
+
+    # Gather all results concurrently
+    results = []
+    if tasks:
+        results = await asyncio.gather(*tasks)
+
+    # Process results
+    for i, errors in enumerate(results):
+        comp_health = task_metadata[i]
 
         if isinstance(errors, dict) and "entries" in errors:
             error_count = len(errors.get("entries", []))
             if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(f"GKE {cluster_name}: {error_count} errors")
+                comp_health["status"] = "DEGRADED"
+                comp_health["issues"].append(f"{error_count} recent errors")
 
-        health["components"].append(component_health)
+                name_prefix = (
+                    "Cloud Run" if comp_health["type"] == "cloud_run" else "GKE"
+                )
+                health["issues"].append(
+                    f"{name_prefix} {comp_health['name']}: {error_count} errors"
+                )
+
+        health["components"].append(comp_health)
 
     # Check Cloud SQL instances
     for sql in resources.get("cloud_sql_instances", []):


### PR DESCRIPTION
💡 What: Refactored `get_application_health` in `sre_agent/tools/clients/app_telemetry.py` to use `asyncio.gather` for parallelizing independent `run_in_threadpool` log queries across Cloud Run services and GKE clusters.
🎯 Why: The original implementation iterated over components sequentially, creating an N+1 query bottleneck. Parallelizing these independent calls significantly reduces overall latency.
📊 Impact: Reduces the latency of the `get_application_health` tool from O(N) API calls latency to O(1) in the best case, substantially speeding up the response time for applications with many components.
🔬 Measurement: Can be measured by calling `get_application_health` on an application with multiple Cloud Run or GKE services and observing the reduced total tool execution time.

---
*PR created automatically by Jules for task [357579399680688455](https://jules.google.com/task/357579399680688455) started by @srtux*