### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,6 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+## 2024-05-19 - [Performance Optimization: Batching Asynchronous API Queries]
+**Learning:** In Google Cloud telemetry queries (like `_list_time_series_sync` or `_list_log_entries_sync` wrapped in `run_in_threadpool`), executing these network I/O bound calls sequentially within a loop for multiple application components (e.g. iterating over GKE clusters or Cloud Run services) creates significant N+1 latency bottlenecks.
+**Action:** When iterating over components to fetch independent telemetry data, always aggregate the `run_in_threadpool` tasks into a list and execute them concurrently using `await asyncio.gather(*tasks)`. Pair this with a parallel metadata list and use `zip(metadata, results, strict=True)` to safely reconstruct the responses back to their originating components.

--- a/sre_agent/tools/clients/app_telemetry.py
+++ b/sre_agent/tools/clients/app_telemetry.py
@@ -12,6 +12,7 @@ It enables the SRE agent to:
 Reference: https://cloud.google.com/app-hub/docs/overview
 """
 
+import asyncio
 import logging
 from typing import Any
 from urllib.parse import urlparse
@@ -304,16 +305,26 @@ async def get_application_metrics(
         "components": [],
     }
 
+    # ⚡ Bolt Optimization: Use asyncio.gather to query metrics concurrently instead of sequentially
+    tasks = []
+    metadata = []
+
     for resource_filter in metric_filters:
         full_filter = f'metric.type="{metric_type}" AND {resource_filter}'
-        metric_data = await run_in_threadpool(
-            _list_time_series_sync,
-            project_id,
-            full_filter,
-            minutes_ago,
-            tool_context,
+        tasks.append(
+            run_in_threadpool(
+                _list_time_series_sync,
+                project_id,
+                full_filter,
+                minutes_ago,
+                tool_context,
+            )
         )
+        metadata.append(resource_filter)
 
+    gathered_results = await asyncio.gather(*tasks)
+
+    for resource_filter, metric_data in zip(metadata, gathered_results, strict=True):
         if isinstance(metric_data, list):
             results["components"].append(
                 {
@@ -517,14 +528,18 @@ async def get_application_health(
         "components": [],
     }
 
-    # Check each Cloud Run service
+    # ⚡ Bolt Optimization: Batch I/O requests to retrieve log entries for Cloud Run and GKE
+    cr_tasks = []
+    cr_metadata = []
+
+    # Prepare Cloud Run tasks
     for svc in resources.get("cloud_run_services", []):
         service_name = svc.get("service", "")
         location_name = svc.get("location", "")
         if not service_name:
             continue
 
-        component_health: dict[str, Any] = {
+        cr_health: dict[str, Any] = {
             "type": "cloud_run",
             "name": service_name,
             "location": location_name,
@@ -532,85 +547,102 @@ async def get_application_health(
             "issues": [],
         }
 
-        # Check for recent errors
         error_filter = (
             f'resource.type="cloud_run_revision" AND '
             f'resource.labels.service_name="{service_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+
+        cr_tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
+        cr_metadata.append(cr_health)
 
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(
-                    f"Cloud Run {service_name}: {error_count} errors"
-                )
+    # Execute Cloud Run queries concurrently
+    if cr_tasks:
+        cr_results = await asyncio.gather(*cr_tasks)
+        for cr_health_item, errors in zip(cr_metadata, cr_results, strict=True):
+            if isinstance(errors, dict) and "entries" in errors:
+                error_count = len(errors.get("entries", []))
+                if error_count > 0:
+                    cr_health_item["status"] = "DEGRADED"
+                    cr_health_item["issues"].append(f"{error_count} recent errors")
+                    health["issues"].append(
+                        f"Cloud Run {cr_health_item['name']}: {error_count} errors"
+                    )
+            health["components"].append(cr_health_item)
 
-        health["components"].append(component_health)
-
-    # Check GKE clusters
+    # Prepare GKE tasks
     seen_clusters: set[str] = set()
+    gke_tasks = []
+    gke_metadata = []
+
     for cluster in resources.get("gke_clusters", []):
         cluster_name = cluster.get("cluster", "")
         if not cluster_name or cluster_name in seen_clusters:
             continue
         seen_clusters.add(cluster_name)
 
-        component_health = {
+        gke_health: dict[str, Any] = {
             "type": "gke_cluster",
             "name": cluster_name,
             "status": "HEALTHY",
             "issues": [],
         }
 
-        # Check for pod errors
         error_filter = (
             f'resource.type="k8s_container" AND '
             f'resource.labels.cluster_name="{cluster_name}" AND '
             f"severity>=ERROR"
         )
-        errors = await run_in_threadpool(
-            _list_log_entries_sync,
-            project_id,
-            error_filter,
-            10,
-            None,
-            tool_context,
+
+        gke_tasks.append(
+            run_in_threadpool(
+                _list_log_entries_sync,
+                project_id,
+                error_filter,
+                10,
+                None,
+                tool_context,
+            )
         )
+        gke_metadata.append(gke_health)
 
-        if isinstance(errors, dict) and "entries" in errors:
-            error_count = len(errors.get("entries", []))
-            if error_count > 0:
-                component_health["status"] = "DEGRADED"
-                component_health["issues"].append(f"{error_count} recent errors")
-                health["issues"].append(f"GKE {cluster_name}: {error_count} errors")
+    # Execute GKE queries concurrently
+    if gke_tasks:
+        gke_results = await asyncio.gather(*gke_tasks)
+        for gke_health_item, errors in zip(gke_metadata, gke_results, strict=True):
+            if isinstance(errors, dict) and "entries" in errors:
+                error_count = len(errors.get("entries", []))
+                if error_count > 0:
+                    gke_health_item["status"] = "DEGRADED"
+                    gke_health_item["issues"].append(f"{error_count} recent errors")
+                    health["issues"].append(
+                        f"GKE {gke_health_item['name']}: {error_count} errors"
+                    )
+            health["components"].append(gke_health_item)
 
-        health["components"].append(component_health)
-
-    # Check Cloud SQL instances
+    # Check Cloud SQL instances (No I/O involved in original loop, kept sequential)
     for sql in resources.get("cloud_sql_instances", []):
         instance = sql.get("instance", "")
         if not instance:
             continue
 
-        component_health = {
+        sql_health: dict[str, Any] = {
             "type": "cloud_sql",
             "name": instance,
             "status": "HEALTHY",
             "issues": [],
         }
 
-        health["components"].append(component_health)
+        health["components"].append(sql_health)
 
     # Determine overall health status
     degraded_count = sum(


### PR DESCRIPTION
💡 What: Replaced sequential `run_in_threadpool` API and log queries with concurrent `asyncio.gather` execution in `get_application_metrics` and `get_application_health` of `sre_agent/tools/clients/app_telemetry.py`.
🎯 Why: To eliminate N+1 latency bottlenecks when querying telemetry for applications with multiple components, significantly reducing total response time.
📊 Impact: O(1) time complexity instead of O(N) for I/O bound queries across application components. Network requests are now batched concurrently.
🔬 Measurement: Measure the execution time of `get_application_metrics` and `get_application_health` for an application with many components (e.g., 5+ Cloud Run services and GKE clusters). Expected to be up to N times faster, bounded by the slowest individual request.

---
*PR created automatically by Jules for task [10565684235885861187](https://jules.google.com/task/10565684235885861187) started by @srtux*