### PR TITLE
⚡ Bolt: Replace slow statistics module with fast native math utils

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2025-02-18 - [Single Fetch for Composite Tools]
 **Learning:** Composite "Mega-Tools" like `analyze_trace_comprehensive` often call multiple granular tools sequentially. If each granular tool fetches its own data, this results in significant redundant API calls (e.g., fetching the same trace 5 times).
 **Action:** Refactor granular tools to separate logic (into `_impl` functions that accept data objects) from I/O. Have the composite tool fetch data once and pass it to the `_impl` functions. This reduced API calls from 5 to 1 and latency from ~500ms to ~100ms in testing.
+
+## 2024-05-22 - Python `statistics` module overhead
+**Learning:** Python's standard `statistics` module functions (`mean`, `median`, `stdev`, `variance`) are implemented in pure Python and handle high-precision fractions and decimals. This adds significant overhead compared to simple native math operations (e.g. `sum(x)/len(x)`). For performance-critical data processing where extreme precision is not required (like trace latency analysis), this overhead can become a bottleneck.
+**Action:** Replace `statistics` module calls with custom, lightweight implementations using native Python math (`sum`, `math.sqrt`) in a centralized utility module (`sre_agent/tools/common/math_utils.py`) for measurable speedups in trace analysis tools.

--- a/sre_agent/tools/analysis/metrics/statistics.py
+++ b/sre_agent/tools/analysis/metrics/statistics.py
@@ -1,9 +1,9 @@
 """Statistical analysis for time series data."""
 
-import statistics
 from typing import Any
 
 from sre_agent.schema import BaseToolResponse, ToolStatus
+from sre_agent.tools.common.math_utils import _mean, _median, _stdev, _variance
 
 from ...common.decorators import adk_tool
 
@@ -31,13 +31,13 @@ def calculate_series_stats(
         "count": float(count),
         "min": points_sorted[0],
         "max": points_sorted[-1],
-        "mean": statistics.mean(points_sorted),
-        "median": statistics.median(points_sorted),
+        "mean": _mean(points_sorted),
+        "median": _median(points_sorted),
     }
 
     if count > 1:
-        stats["stdev"] = statistics.stdev(points_sorted)
-        stats["variance"] = statistics.variance(points_sorted)
+        stats["stdev"] = _stdev(points_sorted)
+        stats["variance"] = _variance(points_sorted)
         stats["p90"] = points_sorted[int(count * 0.9)]
         stats["p95"] = points_sorted[int(count * 0.95)]
         stats["p99"] = points_sorted[int(count * 0.99)]

--- a/sre_agent/tools/analysis/trace/filters.py
+++ b/sre_agent/tools/analysis/trace/filters.py
@@ -1,10 +1,10 @@
 """Trace filter utilities for building Cloud Trace query strings."""
 
 import logging
-import statistics
 from typing import Any
 
 from sre_agent.schema import BaseToolResponse, ToolStatus
+from sre_agent.tools.common.math_utils import _mean, _stdev
 
 from ...common import adk_tool
 
@@ -24,8 +24,8 @@ class TraceSelector:
             return []
 
         latencies = [trace.get("latency", 0) for trace in traces]
-        mean_latency = statistics.mean(latencies)
-        std_dev_latency = statistics.stdev(latencies) if len(latencies) > 1 else 0
+        mean_latency = _mean(latencies)
+        std_dev_latency = _stdev(latencies) if len(latencies) > 1 else 0
 
         threshold = mean_latency + 2 * std_dev_latency
 

--- a/sre_agent/tools/analysis/trace/statistical_analysis.py
+++ b/sre_agent/tools/analysis/trace/statistical_analysis.py
@@ -2,12 +2,12 @@
 
 import concurrent.futures
 import logging
-import statistics
 from collections import defaultdict
 from datetime import datetime
 from typing import Any, cast
 
 from sre_agent.schema import BaseToolResponse, ToolStatus
+from sre_agent.tools.common.math_utils import _mean, _median, _stdev, _variance
 
 from ...clients.trace import fetch_trace_data
 from ...common import adk_tool
@@ -127,16 +127,16 @@ def _compute_latency_statistics_impl(
         "count": count,
         "min": latencies[0],
         "max": latencies[-1],
-        "mean": statistics.mean(latencies),
-        "median": statistics.median(latencies),
+        "mean": _mean(latencies),
+        "median": _median(latencies),
         "p90": latencies[int(count * 0.9)] if count > 0 else latencies[0],
         "p95": latencies[int(count * 0.95)] if count > 0 else latencies[0],
         "p99": latencies[int(count * 0.99)] if count > 0 else latencies[0],
     }
 
     if count > 1:
-        stats["stdev"] = statistics.stdev(latencies)
-        stats["variance"] = statistics.variance(latencies)
+        stats["stdev"] = _stdev(latencies)
+        stats["variance"] = _variance(latencies)
     else:
         stats["stdev"] = 0
         stats["variance"] = 0
@@ -148,7 +148,7 @@ def _compute_latency_statistics_impl(
             continue
         durs.sort()
         c = len(durs)
-        span_mean = statistics.mean(durs)
+        span_mean = _mean(durs)
         per_span_stats[name] = {
             "count": c,
             "mean": span_mean,
@@ -158,8 +158,8 @@ def _compute_latency_statistics_impl(
         }
         # Calculate stdev for Z-score anomaly detection (need at least 2 samples)
         if c > 1:
-            per_span_stats[name]["stdev"] = statistics.stdev(durs)
-            per_span_stats[name]["variance"] = statistics.variance(durs)
+            per_span_stats[name]["stdev"] = _stdev(durs)
+            per_span_stats[name]["variance"] = _variance(durs)
         else:
             per_span_stats[name]["stdev"] = 0
             per_span_stats[name]["variance"] = 0
@@ -583,7 +583,7 @@ def perform_causal_analysis(
 
         if not baseline_durations:
             continue
-        baseline_avg = statistics.mean(baseline_durations)
+        baseline_avg = _mean(baseline_durations)
         diff_ms = target_duration - baseline_avg
         diff_percent = (diff_ms / baseline_avg * 100) if baseline_avg > 0 else 0
 
@@ -701,8 +701,8 @@ def analyze_trace_patterns(
         if perf["occurrences"] < 2:
             continue
         durs = perf["durations"]
-        mean_dur = statistics.mean(durs)
-        stdev_dur: float = statistics.stdev(durs) if len(durs) > 1 else 0.0
+        mean_dur = _mean(durs)
+        stdev_dur: float = _stdev(durs) if len(durs) > 1 else 0.0
         cv = stdev_dur / mean_dur if mean_dur > 0 else 0.0
 
         if mean_dur > 100 and cv < 0.3:
@@ -737,8 +737,8 @@ def analyze_trace_patterns(
 
     trend = "stable"
     if len(trace_durations) >= 3:
-        first = statistics.mean(trace_durations[: len(trace_durations) // 2])
-        second = statistics.mean(trace_durations[len(trace_durations) // 2 :])
+        first = _mean(trace_durations[: len(trace_durations) // 2])
+        second = _mean(trace_durations[len(trace_durations) // 2 :])
         diff = ((second - first) / first * 100) if first > 0 else 0
         if diff > 15:
             trend = "degrading"

--- a/sre_agent/tools/clients/trace.py
+++ b/sre_agent/tools/clients/trace.py
@@ -18,7 +18,6 @@ import json
 import logging
 import os
 import re
-import statistics
 import time
 from collections.abc import Coroutine
 from datetime import datetime, timezone
@@ -36,6 +35,7 @@ from sre_agent.auth import (
 from sre_agent.schema import BaseToolResponse, ToolStatus
 from sre_agent.tools.common import adk_tool
 from sre_agent.tools.common.cache import get_data_cache
+from sre_agent.tools.common.math_utils import _mean, _median, _stdev
 
 __all__ = [
     "_clear_thread_credentials",
@@ -727,9 +727,9 @@ async def find_example_traces(
 
             latencies = [t["duration_ms"] for t in valid_traces]
             latencies.sort()
-            p50 = statistics.median(latencies)
-            mean = statistics.mean(latencies)
-            stdev = statistics.stdev(latencies) if len(latencies) > 1 else 0
+            p50 = _median(latencies)
+            mean = _mean(latencies)
+            stdev = _stdev(latencies) if len(latencies) > 1 else 0
 
             for trace in valid_traces:
                 has_err = (

--- a/sre_agent/tools/common/math_utils.py
+++ b/sre_agent/tools/common/math_utils.py
@@ -1,0 +1,31 @@
+import math
+from collections.abc import Sequence
+
+
+def _mean(data: Sequence[float | int]) -> float:
+    if not data:
+        raise ValueError("mean requires at least one data point")
+    return float(sum(data)) / len(data)
+
+
+def _median(data: Sequence[float | int]) -> float:
+    if not data:
+        raise ValueError("median requires at least one data point")
+    s = sorted(data)
+    n = len(s)
+    mid = n // 2
+    if n % 2 == 0:
+        return float((s[mid - 1] + s[mid]) / 2.0)
+    return float(s[mid])
+
+
+def _variance(data: Sequence[float | int]) -> float:
+    n = len(data)
+    if n < 2:
+        raise ValueError("variance requires at least two data points")
+    m = _mean(data)
+    return float(sum((x - m) ** 2 for x in data)) / (n - 1)
+
+
+def _stdev(data: Sequence[float | int]) -> float:
+    return float(math.sqrt(_variance(data)))

--- a/sre_agent/tools/synthetic/demo_data_generator.py
+++ b/sre_agent/tools/synthetic/demo_data_generator.py
@@ -9,10 +9,10 @@ from __future__ import annotations
 
 import math
 import random
-import statistics
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from sre_agent.tools.common.math_utils import _mean
 from sre_agent.tools.synthetic.cymbal_assistant import (
     AGENTS,
     ANOMALOUS_DELEGATION,
@@ -1129,7 +1129,7 @@ class DemoDataGenerator:
 
         nodes = []
         for nid, ns in node_stats.items():
-            avg_dur = statistics.mean(ns["durations"]) if ns["durations"] else 0.0
+            avg_dur = _mean(ns["durations"]) if ns["durations"] else 0.0
             nodes.append(
                 {
                     "id": nid,
@@ -1148,7 +1148,7 @@ class DemoDataGenerator:
 
         edges = []
         for (src, tgt), es in edge_stats.items():
-            avg_dur = statistics.mean(es["durations"]) if es["durations"] else 0.0
+            avg_dur = _mean(es["durations"]) if es["durations"] else 0.0
             edges.append(
                 {
                     "id": f"{src}->{tgt}",
@@ -1372,7 +1372,7 @@ class DemoDataGenerator:
             "callCount": call_count,
             "errorCount": error_count,
             "errorRate": round(error_rate, 4),
-            "avgDurationMs": round(statistics.mean(durations), 2) if durations else 0.0,
+            "avgDurationMs": round(_mean(durations), 2) if durations else 0.0,
             "p95DurationMs": round(_percentile(durations, 95), 2),
             "p99DurationMs": round(_percentile(durations, 99), 2),
             "totalTokens": input_tokens + output_tokens,
@@ -1430,7 +1430,7 @@ class DemoDataGenerator:
                 durations = [self._span_duration_ms(s) for s in spans]
                 tokens = sum(self._span_tokens(s) for s in spans)
                 errors = sum(1 for s in spans if self._span_has_error(s))
-                avg_dur = statistics.mean(durations) if durations else 0.0
+                avg_dur = _mean(durations) if durations else 0.0
                 points.append(
                     {
                         "bucket": key,
@@ -1575,7 +1575,7 @@ class DemoDataGenerator:
 
         # Current period
         total_sessions = len(sessions)
-        avg_turns = statistics.mean([s["turns"] for s in sessions]) if sessions else 0.0
+        avg_turns = _mean([s["turns"] for s in sessions]) if sessions else 0.0
         root_invocations = len(traces)
         error_traces = sum(
             1 for t in traces if any(s["status"]["code"] == 2 for s in t["spans"])
@@ -1597,7 +1597,7 @@ class DemoDataGenerator:
             sid = t["session_id"]
             prev_session_turns[sid] = prev_session_turns.get(sid, 0) + 1
         prev_avg_turns = (
-            statistics.mean(prev_session_turns.values()) if prev_session_turns else 0.0
+            _mean(list(prev_session_turns.values())) if prev_session_turns else 0.0
         )
 
         def _trend(current: float, previous: float) -> float:
@@ -1867,9 +1867,7 @@ class DemoDataGenerator:
                     "latestTraceId": st[-1]["trace_id"],
                     "totalTokens": total_tokens,
                     "errorCount": error_count,
-                    "avgLatencyMs": round(statistics.mean(latencies), 2)
-                    if latencies
-                    else 0.0,
+                    "avgLatencyMs": round(_mean(latencies), 2) if latencies else 0.0,
                     "p95LatencyMs": round(_percentile(latencies, 95), 2),
                     "agentName": "cymbal-assistant",
                     "resourceId": REASONING_ENGINE_ID,
@@ -2029,7 +2027,7 @@ class DemoDataGenerator:
                     "executionCount": ts["calls"],
                     "errorCount": ts["errors"],
                     "errorRate": round(err_rate, 4),
-                    "avgDurationMs": round(statistics.mean(ts["durations"]), 2)
+                    "avgDurationMs": round(_mean(ts["durations"]), 2)
                     if ts["durations"]
                     else 0.0,
                     "p95DurationMs": round(_percentile(ts["durations"], 95), 2),


### PR DESCRIPTION
💡 What: Replaced Python's standard `statistics` module calls (`mean`, `median`, `variance`, `stdev`) with custom, lightweight implementations using native math (`sum`, `math.sqrt`) centralized in `sre_agent/tools/common/math_utils.py`.
🎯 Why: The standard `statistics` module is implemented in pure Python and handles high-precision fractions and decimals, adding significant overhead compared to simple native math operations. For trace latency analysis, this overhead creates an unnecessary bottleneck.
📊 Impact: Reduces computational overhead for statistical analysis over large lists of numbers, improving the overall execution speed of tracing tools.
🔬 Measurement: Profile the execution time of `calculate_series_stats` or `analyze_trace_patterns` with large datasets before and after the change to observe the latency reduction.

---
*PR created automatically by Jules for task [10608080401325620701](https://jules.google.com/task/10608080401325620701) started by @srtux*